### PR TITLE
chore(workflow/npm): fix `install deps` step

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -43,7 +43,7 @@ jobs:
         run: git reset --hard ${{ steps.get_latest_tag.outputs.tag }}
       
       - name: Install Dependencies
-        run: pnpm install --filter astro-portabletext
+        run: pnpm install
 
       - name: Publish
         run: pnpm publish --filter astro-portabletext --no-git-checks


### PR DESCRIPTION
Remove --filter flag to fix "Cannot install with 'frozen-lockfile'" error