### PR TITLE
fix(release): fix bad release

### DIFF
--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-portabletext",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "Render Portable Text with Astro",
   "keywords": [

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "private": true,
   "author": "Tom Theisel <tom.theisel@gmail.com>",


### PR DESCRIPTION
Bump versions as 216ed544 had no effect on creating a new release

- Bump `astro-portabletext` version
- Bump `demo` version
- Lockfile was fixed in d7b68707 following release