### PR TITLE
chore(husky): remove `compile` script

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm install
-pnpm --filter astro-portabletext compile


### PR DESCRIPTION
Script has no effect as it was dropped from the `astro-portabletext` package