### PR TITLE
ci(workflow/test): drop Node v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [18, 20]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Astro no longer supports Node v16