### PR TITLE
fix(astro-portabletext): update dependencies and fix #92

### DIFF
--- a/astro-portabletext/lib/types.ts
+++ b/astro-portabletext/lib/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   ToolkitListNestMode,
   ToolkitNestedPortableTextSpan,
@@ -24,7 +25,7 @@ export type { TypedObject } from "@portabletext/types";
  * @template Value Portable Text payload
  */
 export interface PortableTextProps<
-  Value extends TypedObject = PortableTextBlock | ArbitraryTypedObject
+  Value extends TypedObject = PortableTextBlock | ArbitraryTypedObject,
 > {
   /**
    * Portable Text blocks
@@ -89,11 +90,11 @@ export interface PortableTextComponents {
   /**
    * How marked text should be rendered
    */
-  mark: ComponentOrRecord<Mark<Record<string, unknown>>>;
+  mark: ComponentOrRecord<Mark<Record<string, any>>> | ComponentOrRecord<Mark>;
   /**
    * Used when a `mark` handler isn't found
    */
-  unknownMark: Component<Mark<Record<string, unknown>>>;
+  unknownMark: Component<Mark<Record<string, any>>> | Component<Mark>;
   /**
    * How line breaks should be rendered
    */
@@ -176,7 +177,7 @@ export type ListItem = ToolkitPortableTextListItem;
  * export type Props = $<Mark<{ msg: string }>>;
  */
 export interface Mark<
-  MarkDef extends Record<string, unknown> | undefined = undefined
+  MarkDef extends Record<string, unknown> | undefined = undefined,
 > extends ToolkitNestedPortableTextSpan {
   markDef: MarkDef & PortableTextMarkDefinition;
   markKey: string;

--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -43,7 +43,7 @@
     "check": "astro check --root components"
   },
   "dependencies": {
-    "@portabletext/toolkit": "^2.0.8",
-    "@portabletext/types": "^2.0.6"
+    "@portabletext/toolkit": "^2.0.10",
+    "@portabletext/types": "^2.0.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,11 +63,11 @@ importers:
   astro-portabletext:
     dependencies:
       '@portabletext/toolkit':
+        specifier: ^2.0.10
+        version: 2.0.10
+      '@portabletext/types':
         specifier: ^2.0.8
         version: 2.0.8
-      '@portabletext/types':
-        specifier: ^2.0.6
-        version: 2.0.6
 
   demo:
     dependencies:
@@ -1684,15 +1684,15 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@portabletext/toolkit@2.0.8:
-    resolution: {integrity: sha512-MI3FKYZiL+/dYsClkkTDRjSvNS7K4j+U2LNZ5XIEoq67qCY0l7CYjvT0fn+lFBEUxjegtEmbxLk6T9nV/iXA+Q==}
+  /@portabletext/toolkit@2.0.10:
+    resolution: {integrity: sha512-d+F9JvpnMEx7kd6saZ9OWA4U1Iwuokh6TOht7iqkfWU+0ivh9yM4v+b0Kpu+iiPcElicoabhtXol+yTvWJ1jDw==}
     engines: {node: ^14.13.1 || >=16.0.0}
     dependencies:
-      '@portabletext/types': 2.0.6
+      '@portabletext/types': 2.0.8
     dev: false
 
-  /@portabletext/types@2.0.6:
-    resolution: {integrity: sha512-6iqorcsQ0Z1/4Y7PWLvoknyiUv0DngSPao+q5UIE0+0gT2cZwFdItUyLZRheG85AisSEvacHEEnvN+TT8mxXVg==}
+  /@portabletext/types@2.0.8:
+    resolution: {integrity: sha512-eiq9/kMX2bYezS4/kLFk3xNnruCFjCDdw6aYEv5ECHVKkYROiuLd3/AsP5d7tWF3+kPPy6tB0Wq8aqDG/URHGA==}
     engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
     dev: false
 


### PR DESCRIPTION
Update dependencies to latest versions
- @portabletext/toolkit
- @portabletext/types

Fix #92 
- Fix `mark` and `unknownMark` types