### PR TITLE
ci: fix actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.CI_TOKEN }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -38,6 +38,6 @@ jobs:
         run: pnpm format
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "style(format): [ci] format"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
         uses: pnpm/action-setup@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'pnpm'

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -29,7 +29,7 @@ jobs:
         uses: pnpm/action-setup@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: | 
           echo "dispatch=${{ steps.release.outputs.releases_created && steps.release.outputs['astro-portabletext--release_created'] || 'false' }}" >> $GITHUB_OUTPUT
   
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.npm.outputs.dispatch == 'true' }}
         with:
           token: ${{ secrets.CI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release / Pull Request
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@v4
         id: release
         with:
           release-type: node
-          command: manifest
 
       - name: Publish to NPM?
         id: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: pnpm/action-setup@v3
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         node-version: [18, 20]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
Upgrade actions

- actions/checkout to v4
- pnpm/action-setup to v3
- actions/setup-node to v4
- stefanzweifel/git-auto-commit-action to v5
- google-github-actions/release-please-action to v4

Upgrade Node version
- Set version to v20