### PR TITLE
refactor(component)!: drop `class` prop from `PortableText`

### DIFF
--- a/astro-portabletext/components/PortableText.astro
+++ b/astro-portabletext/components/PortableText.astro
@@ -39,16 +39,13 @@ import UnknownListItem from "./UnknownListItem.astro";
 import UnknownMark from "./UnknownMark.astro";
 import UnknownType from "./UnknownType.astro";
 
-export interface Props extends PortableTextProps {
-  class?: astroHTML.JSX.HTMLAttributes["class"];
-}
+export type Props = PortableTextProps;
 
 const {
   value,
   components: componentOverrides = {},
   listNestingMode = LIST_NEST_MODE_HTML,
   onMissingComponent = true,
-  class: astroClass,
 } = Astro.props;
 
 const components = mergeComponents(
@@ -124,7 +121,6 @@ const asComponentProps = (
   node,
   index,
   isInline,
-  class: astroClass,
 });
 
 const provideComponent = (

--- a/astro-portabletext/docs/types.md
+++ b/astro-portabletext/docs/types.md
@@ -35,11 +35,6 @@ export interface Props<N extends TypedObject> {
    * Whether the component should be layed out as inline or block element
    */
   isInline: boolean;
-  /**
-   * ⚠️ As of Astro V3, this has no impact and should be ignored.
-   * It will be dropped in future release.
-   */
-  class?: string | undefined | null;
 }
 ```
 

--- a/astro-portabletext/lib/types.ts
+++ b/astro-portabletext/lib/types.ts
@@ -124,10 +124,6 @@ export interface Props<N extends TypedObject> {
    * Whether the component should be layed out as inline or block element
    */
   isInline: boolean;
-  /**
-   * Set when `style` is used within an Astro component, should be used when defined.
-   */
-  class?: string | undefined | null;
 }
 
 /**


### PR DESCRIPTION
Remove `class` prop and don't pass it to the render components as it's unpredictable

BREAKING CHANGE: use `scoped` and `global` styles instead

refactor(types)!: drop `class` from `Props` as it's outside of scope

BREAKING CHANGE: extend `Props` to accept `class`