### PR TITLE
refactor: drop `demo` package versioning

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"astro-portabletext":"0.10.0","demo":"0.2.0"}
+{ "astro-portabletext": "0.10.0" }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,9 +25,6 @@
   "packages": {
     "astro-portabletext": {
       "package-name": "astro-portabletext"
-    },
-    "demo": {
-      "package-name": "demo"
     }
   }
 }


### PR DESCRIPTION
Update `release-please` configuration and manifest. Separate `demo` versioning isn't needed.