### PR TITLE
chore(release): update release-please action and config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release / Pull Request
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         id: release
 
       - name: Publish to NPM?

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"astro-portabletext":"0.10.0"}
+{"astro-portabletext":"0.10.1"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "ed6f8096f4ca1dbd7e23a9b1983d378548059d7d",
+  "last-release-sha": "2156f18ce5cf3967cdfb7f6bce0203d5316eb8b6",
   "bump-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": false,


### PR DESCRIPTION
This updates the release workflow and manifest to address the recent release failure.

The following changes were made:

* Updated the release-please action to the recommended `googleapis/release-please-action`.
* Updated the release-please manifest to reflect the correct version in `astro-portabletext/package.json`.
* Updated the `last-release-sha` in the workflow configuration.

This should ensure that future releases are generated correctly.