### PR TITLE
chore(release): correct last-release-sha in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "2156f18ce5cf3967cdfb7f6bce0203d5316eb8b6",
+  "last-release-sha": "27ce84c5401cadb996cc5902adf98637f984e7f1",
   "bump-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": false,


### PR DESCRIPTION
Corrects the `last-release-sha` in the release-please config to point to the last successful release.