### PR TITLE
chore(release): update last-release-sha to reflect manual release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "27ce84c5401cadb996cc5902adf98637f984e7f1",
+  "last-release-sha": "cffbdf8deff5522516124615e694ee9754c23e07",
   "bump-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": false,


### PR DESCRIPTION
Updates the `last-release-sha` in the release-please configuration to reflect the recent manual release, ensuring accurate release tracking.