### PR TITLE
feat(api): enhance customisation with `slots` and `render` function

### DIFF
--- a/astro-portabletext/README.md
+++ b/astro-portabletext/README.md
@@ -7,62 +7,65 @@
 ![license](https://img.shields.io/npm/l/astro-portabletext?style=flat-square)
 [![npm](https://img.shields.io/npm/v/astro-portabletext?style=flat-square)](https://www.npmjs.com/package/astro-portabletext)
 
-&nbsp;
+Effortlessly integrate [Portable Text](https://portabletext.org) into your [Astro](https://astro.build) projects, with extensive customisation options to perfectly match your vision.
 
-Render [Portable Text](https://portabletext.org/) with [Astro](https://astro.build/).
+## 🎮 Play around
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/theisel/astro-portabletext/tree/main/demo)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/theisel/astro-portabletext/tree/main/demo)
+Jump in and see it in action:
 
-&nbsp;
+<div>
+  <a href="https://stackblitz.com/github/theisel/astro-portabletext/tree/main/demo">
+    <img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz">
+  </a>
+  <a href="https://codesandbox.io/p/sandbox/github/theisel/astro-portabletext/tree/main/demo">
+    <img src="https://assets.codesandbox.io/github/button-edit-lime.svg" alt="Open in CodeSandbox">
+  </a>
+</div>
 
-## Table of Contents
+## ✨ Why use `astro-portabletext`?
 
-- [Getting Started](#getting-started)
-- [Documentation](#documentation)
-- [License](#license)
+It provides a seamless way to render Portable Text in Astro, with a focus on performance, flexibility, and ease of use:
 
-&nbsp;
+- 🚀 **Speed and simplicity:** Minimised client-side JS for faster loads, with Astro's islands working its magic.
+- 🎨 **Make it yours:** Pre-built components are great, but you can tweak them, extend them, and make them totally yours with slots and custom components.
+- 📢 **Recommended by Sanity:** [Officially recommended](https://www.sanity.io/plugins/sanity-astro#rendering-rich-text-and-block-content-with-portable-text) for rendering Portable Text in Astro projects.
 
-## Getting Started
+## 🚀 Features
 
-### Install
+- 🧩 **Core components:** Includes pre-built components for essential Portable Text elements, giving you a solid foundation to build upon.
+- 🔧 **Customisable:** Use `slots` for light tweaks or bring in your custom `components` for complete control.
+- 🛠 **Fine-tune node rendering:** Use the `render` function from `usePortableText` for extra control over child node output.
+- 📘 **Typescript:** Full TypeScript support means you can build with confidence.
+
+## 📦 Install it
+
+Pick your favourite package manager and run one of these:
 
 ```bash
-$ npm install astro-portabletext
-# $ pnpm add astro-portabletext
-# $ yarn add astro-portabletext
+npm install astro-portabletext
+# or
+pnpm add astro-portabletext
+# or
+yarn add astro-portabletext
+# or
+bun add astro-portabletext
 ```
 
-### Usage
+## 🧑‍💻 Let's get coding
 
-| Import                          | Description                                                                                                                       |
-| :------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
-| `astro-portabletext`            | For `PortableText` component. <br>See [PortableText Component](docs/portabletext-component.md) for details.                       |
-| `astro-portabletext/components` | For `Block`, `List`, `ListItem` and `Mark` components. <br> See [Extending Components](docs/extending-components.md) for details. |
-| `astro-portabletext/types`      | For Typescript [types](docs/types.md)                                                                                             |
-| `astro-portabletext/utils`      | For [utility](docs/utils.md) functions                                                                                            |
+Ready to render some Portable Text? Here's a quick start.
 
-```ts
-/* .astro file */
----
-import { PortableText } from "astro-portabletext";
----
+### Basic
 
-<PortableText
-  value=/* Required */
-  components=/* Optional */
-  onMissingComponent=/* Optional */
-  listNestingMode=/* Optional */
-/>
-```
+Import the `PortableText` component into your `.astro` file and start rendering. It's that simple! You can even override the defaults if you want to get fancy.
 
-**astro-portabletext** components will render the following:
+<details>
+  <summary>Peek at the default structure</summary>
 
 ```js
 {
   type: {
-    /* custom types go here */
+    /* Custom types go here */
   },
   block: {
     h1: /* <h1 {...attrs}><slot /></h1> */,
@@ -92,19 +95,192 @@ import { PortableText } from "astro-portabletext";
     strong: /* <strong {...attrs}><slot /></strong> */,
     underline: /* <span {...attrs} style="text-decoration: underline;"><slot /></span> */
   },
-  text: /* renders string; use custom handler to change output */
+  text: /* Renders plain text */
   hardBreak: /* <br /> */,
 }
 ```
 
-&nbsp;
+</details>
 
-## Documentation
+```js
+/* .astro */
+---
+import { PortableText } from "astro-portabletext";
 
-Refer to [docs](docs/README.md) page for advanced usage and examples, including implementation with [Sanity](docs/sanity.md).
+const portableText = [
+  {
+    _type: 'block',
+    _key: 'a1ph4',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        _key: 'c961f',
+        text: 'This is a Portable Text example.',
+        marks: [],
+      },
+    ],
+  },
+];
+---
 
-&nbsp;
+<PortableText value={portableText} />
+```
 
-## License
+### Customisation
 
-ISC
+#### Slots - Tweak it just right
+
+Sometimes you just need to nudge things here and there. Use `slots` for those quick customisations without breaking a sweat.
+
+```js
+/* .astro */
+---
+import { PortableText } from "astro-portabletext";
+
+const portableText = [
+  {
+    _type: 'block',
+    _key: 'a1ph4',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        _key: 'c961f',
+        text: 'This is a Portable Text example.',
+        marks: [],
+      },
+    ],
+  },
+];
+---
+
+<PortableText value={portableText}>
+  <fragment slot="block">{({ Component, props, children }) => (
+    <Component {...props} class="block">{children}</Component>
+  )}</fragment>
+</PortableText>
+
+<style>
+  .block:where(h1, h2) {
+    /* some styles */
+  }
+</style>
+```
+
+#### Custom components - Full control
+
+Want to take things to the next level? Bring in your own custom components to fully control how each part is rendered.
+
+```js
+/* .astro */
+---
+import { PortableText } from "astro-portabletext";
+import MyCustomBlock from "./MyCustomBlock.astro";
+
+const portableText = [
+  {
+    _type: 'block',
+    _key: 'a1ph4',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        _key: 'c961f',
+        text: 'This is a Portable Text example.',
+        marks: [],
+      },
+    ],
+  },
+];
+---
+
+<PortableText
+  value={portableText}
+  components={{ block: MyCustomBlock }}
+/>
+```
+
+#### Mix and match: Ultimate flexibility
+
+Take the best of both worlds! You can use custom components and tweak small details with slots. It's the flexibility you've been looking for.
+
+```js
+/* .astro */
+---
+import { PortableText } from "astro-portabletext";
+import MyCustomBlock from "./MyCustomBlock.astro";
+
+const portableText = [
+  {
+    _type: 'block',
+    _key: 'a1ph4',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        _key: 'c961f',
+        text: 'This is a Portable Text example.',
+        marks: [],
+      },
+    ],
+  },
+];
+---
+
+<PortableText
+  value={portableText}
+  components={{ block: MyCustomBlock }}
+>
+  <fragment slot="block">{({ Component /* MyCustomBlock */, props, children }) => (
+    <Component {...props} class="block">{children}</Component>
+  )}</fragment>
+</PortableText>
+
+<style>
+  .block:where(h1, h2) {
+    /* some styles */
+  }
+</style>
+```
+
+```ts
+/* MyCustomBlock.astro */
+---
+import type { Block, Props as $ } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+export type Props = $<Block>;
+
+const { node, isInline, index, ...attrs} = Astro.props;
+const { render, getDefaultComponent } = usePortableText(node);
+
+const DefaultBlock = getDefaultComponent(); // In this `block` context, it returns `astro-portabletext` block component
+
+const styleIs = (style: string) => style === node.style;
+---
+
+{
+  styleIs("h1") ? (
+    <h1 {...attrs}>{render({
+      text: ({ props }) => props.node.text.replace("fox", "🦊") // Use the render function to customise the output
+    })}</h1>
+  ) : (
+    <DefaultBlock {...Astro.props}>
+      <slot />
+    </DefaultBlock>
+  )
+}
+```
+
+## 📖 Documentation
+
+For all the fine details, check out the [docs](docs/README.md), including guides for integrating with [Sanity](docs/sanity.md).
+
+## 📄 License
+
+This project is licensed under the [ISC License](https://github.com/theisel/astro-portabletext/blob/main/LICENSE).

--- a/astro-portabletext/components/PortableText.astro
+++ b/astro-portabletext/components/PortableText.astro
@@ -10,13 +10,12 @@ import {
   LIST_NEST_MODE_HTML,
 } from "@portabletext/toolkit";
 
-import type { PortableTextBlock } from "@portabletext/types";
-
 import type {
   MissingComponentHandler,
   PortableTextComponents,
   PortableTextProps,
   Props as ComponentProps,
+  RenderOptions,
   TypedObject,
 } from "../lib/types";
 
@@ -104,24 +103,11 @@ const missingComponentHandler = ((
   return !handler ? noop : printWarning;
 })(onMissingComponent);
 
-const serializeNode =
-  (isInline: boolean) =>
-  (node: TypedObject, index: number = 0) =>
-    asComponentProps(node, index, isInline);
-
-const serializeChildren = (
-  node: TypedObject & { children: TypedObject[] },
-  isInline: boolean
-) => node.children.map(serializeNode(isInline));
-
-const serializeMarksTree = (node: PortableTextBlock) =>
-  buildMarksTree(node).map(serializeNode(true));
-
-const asComponentProps = (
-  node: TypedObject,
+const asComponentProps = <T extends TypedObject>(
+  node: T,
   index: number,
   isInline: boolean
-): ComponentProps<typeof node> => ({
+): ComponentProps<T> => ({
   node,
   index,
   isInline,
@@ -148,84 +134,128 @@ const provideComponent = (
   return fallbackComponent;
 };
 
-const prepareForRender = (
-  props: ComponentProps<TypedObject>
-):
-  | [Component | string, ComponentProps<TypedObject>[]]
-  | [Component | string] => {
-  const { node } = props;
+// The local render function will override these options
+let fallbackRenderOptions: Required<RenderOptions> | undefined;
 
-  if (isPortableTextToolkitList(node)) {
-    return [
-      provideComponent(
-        "list",
-        node.listItem,
-        components.unknownList ?? UnknownList
+const portableTextRender = (options: RenderOptions, isInline?: boolean) => {
+  if (!fallbackRenderOptions) {
+    throw new Error(
+      "[PortableText portableTextRender] fallbackRenderOptions is undefined"
+    );
+  }
+
+  return function renderNode(node: TypedObject, index: number): any {
+    const renderOptions = { ...fallbackRenderOptions, ...(options ?? {}) };
+
+    function run<H extends (...args: any) => any, P = Parameters<H>[0]>(
+      handler: H | undefined,
+      props: P
+    ) {
+      if (!isComponent(handler)) {
+        throw new Error(
+          `[PortableText render] No handler found for node type ${node._type}.`
+        );
+      }
+
+      return handler(props);
+    }
+
+    if (isPortableTextToolkitList(node)) {
+      const UnknownComponent = components.unknownList ?? UnknownList;
+
+      return run(renderOptions.list, {
+        Component: provideComponent("list", node.listItem, UnknownComponent),
+        props: asComponentProps(node, index, false),
+        children: node.children?.map(portableTextRender(options, false)),
+      });
+    }
+
+    if (isPortableTextListItemBlock(node)) {
+      const { listItem, ...blockNode } = node;
+      const isStyled = node.style && node.style !== "normal";
+      // Apply block style if defined (and not "normal"), otherwise render with marks.
+      node.children = isStyled
+        ? renderNode(blockNode, index)
+        : buildMarksTree(node);
+
+      const UnknownComponent = components.unknownListItem ?? UnknownListItem;
+
+      return run(renderOptions.listItem, {
+        Component: provideComponent(
+          "listItem",
+          node.listItem,
+          UnknownComponent
+        ),
+        props: asComponentProps(node, index, false),
+        children: isStyled
+          ? node.children
+          : node.children.map(portableTextRender(options, true)),
+      });
+    }
+
+    if (isPortableTextToolkitSpan(node)) {
+      const UnknownComponent = components.unknownMark ?? UnknownMark;
+
+      return run(renderOptions.mark, {
+        Component: provideComponent("mark", node.markType, UnknownComponent),
+        props: asComponentProps(node, index, true),
+        children: node.children?.map(portableTextRender(options, true)),
+      });
+    }
+
+    if (isPortableTextBlock(node)) {
+      node.style ??= "normal"; /* Make sure style has been set */
+      node.children = buildMarksTree(node);
+
+      const UnknownComponent = components.unknownBlock ?? UnknownBlock;
+
+      return run(renderOptions.block, {
+        Component: provideComponent("block", node.style, UnknownComponent),
+        props: asComponentProps(node, index, false),
+        children: node.children.map(portableTextRender(options, true)),
+      });
+    }
+
+    if (isPortableTextToolkitTextNode(node)) {
+      const isHardBreak = "\n" === node.text;
+      const props = asComponentProps(node, index, true);
+
+      if (isHardBreak) {
+        return run(renderOptions.hardBreak, {
+          Component: isComponent(components.hardBreak)
+            ? components.hardBreak
+            : HardBreak,
+          props,
+        });
+      }
+
+      return run(renderOptions.text, {
+        Component: isComponent(components.text) ? components.text : Text,
+        props,
+      });
+    }
+
+    // Custom type
+    const UnknownComponent = components.unknownType ?? UnknownType;
+
+    return run(renderOptions.type, {
+      Component: provideComponent("type", node._type, UnknownComponent),
+      props: asComponentProps(
+        node,
+        index,
+        isInline ?? false /* default to block */
       ),
-      serializeChildren(node, false),
-    ];
-  }
-
-  if (isPortableTextListItemBlock(node)) {
-    return [
-      provideComponent(
-        "listItem",
-        node.listItem,
-        components.unknownListItem ?? UnknownListItem
-      ),
-      serializeMarksTree(node).map((children) => {
-        if (node.style !== "normal") {
-          const { listItem, ...blockNode } = node;
-          children = serializeNode(false)(blockNode, 0);
-        }
-        return children;
-      }),
-    ];
-  }
-
-  if (isPortableTextToolkitSpan(node)) {
-    return [
-      provideComponent(
-        "mark",
-        node.markType,
-        components.unknownMark ?? UnknownMark
-      ),
-      serializeChildren(node, true),
-    ];
-  }
-
-  if (isPortableTextBlock(node)) {
-    return [
-      provideComponent(
-        "block",
-        (node.style ??= "normal") /* Make sure style has been set */,
-        components.unknownBlock ?? UnknownBlock
-      ),
-      serializeMarksTree(node),
-    ];
-  }
-
-  if (isPortableTextToolkitTextNode(node)) {
-    return [
-      "\n" === node.text
-        ? isComponent(components.hardBreak)
-          ? components.hardBreak
-          : HardBreak
-        : isComponent(components.text)
-          ? components.text
-          : Text,
-    ];
-  }
-
-  return [
-    provideComponent("type", node._type, components.unknownType ?? UnknownType),
-  ];
+    });
+  };
 };
 
-(globalThis as any)[contextRef] = (node: TypedObject): Context => {
+(globalThis as any)[contextRef] = (
+  node: TypedObject & { children?: TypedObject[] }
+): Context => {
   return {
     getDefaultComponent: provideDefaultComponent.bind(null, node),
     getUnknownComponent: provideUnknownComponent.bind(null, node),
+    render: (options) => node.children?.map(portableTextRender(options)),
   };
 };
 
@@ -272,25 +302,57 @@ const provideUnknownComponent = (node: TypedObject) => {
 
 // Make sure we have an array of blocks
 const blocks = Array.isArray(value) ? value : [value];
+const nodes = nestLists(blocks, listNestingMode);
 
-// Using a generator to avoid creating a new array
-function* renderBlocks() {
-  let index = 0;
+const render = (options: NonNullable<typeof fallbackRenderOptions>) => {
+  fallbackRenderOptions = options;
+  return portableTextRender(options);
+};
 
-  for (const it of nestLists(blocks, listNestingMode)) {
-    yield asComponentProps(it, index++, false);
-  }
-}
+const hasTypeSlot = Astro.slots.has("type");
+const hasBlockSlot = Astro.slots.has("block");
+const hasListSlot = Astro.slots.has("list");
+const hasListItemSlot = Astro.slots.has("listItem");
+const hasMarkSlot = Astro.slots.has("mark");
+const hasTextSlot = Astro.slots.has("text");
+const hasHardBreakSlot = Astro.slots.has("hardBreak");
+
+// Create a slot renderer for a specific slot
+const createSlotRenderer = (slotName: string) =>
+  Astro.slots.render.bind(Astro.slots, slotName);
+
+type RenderNode = (
+  slotRenderer: ReturnType<typeof createSlotRenderer> | undefined
+) => (
+  props: Parameters<NonNullable<RenderOptions[keyof RenderOptions]>>[0]
+) => any;
 ---
 
 {
-  [...renderBlocks()].map(function render(props) {
-    const [Cmp, children = []] = prepareForRender(props);
+  (() => {
+    const renderNode: RenderNode = (slotRenderer) => {
+      return ({ Component, props, children }) =>
+        slotRenderer?.([{ Component, props, children }]) ?? (
+          <Component {...(props as any)}>{children}</Component>
+        );
+    };
 
-    return !isComponent(Cmp) ? (
-      <Fragment set:text={Cmp} />
-    ) : (
-      <Cmp {...props}>{children.map(render)}</Cmp>
+    return nodes.map(
+      render({
+        type: renderNode(hasTypeSlot ? createSlotRenderer("type") : undefined),
+        block: renderNode(
+          hasBlockSlot ? createSlotRenderer("block") : undefined
+        ),
+        list: renderNode(hasListSlot ? createSlotRenderer("list") : undefined),
+        listItem: renderNode(
+          hasListItemSlot ? createSlotRenderer("listItem") : undefined
+        ),
+        mark: renderNode(hasMarkSlot ? createSlotRenderer("mark") : undefined),
+        text: renderNode(hasTextSlot ? createSlotRenderer("text") : undefined),
+        hardBreak: renderNode(
+          hasHardBreakSlot ? createSlotRenderer("hardBreak") : undefined
+        ),
+      })
     );
-  })
+  })()
 }

--- a/astro-portabletext/components/PortableText.astro
+++ b/astro-portabletext/components/PortableText.astro
@@ -134,6 +134,11 @@ const provideComponent = (
   return fallbackComponent;
 };
 
+const cachedNodes = new WeakMap<
+  TypedObject,
+  { Default?: Component; Unknown?: Component }
+>();
+
 // The local render function will override these options
 let fallbackRenderOptions: Required<RenderOptions> | undefined;
 
@@ -163,6 +168,8 @@ const portableTextRender = (options: RenderOptions, isInline?: boolean) => {
     if (isPortableTextToolkitList(node)) {
       const UnknownComponent = components.unknownList ?? UnknownList;
 
+      cachedNodes.set(node, { Default: List, Unknown: UnknownComponent });
+
       return run(renderOptions.list, {
         Component: provideComponent("list", node.listItem, UnknownComponent),
         props: asComponentProps(node, index, false),
@@ -180,6 +187,8 @@ const portableTextRender = (options: RenderOptions, isInline?: boolean) => {
 
       const UnknownComponent = components.unknownListItem ?? UnknownListItem;
 
+      cachedNodes.set(node, { Default: ListItem, Unknown: UnknownComponent });
+
       return run(renderOptions.listItem, {
         Component: provideComponent(
           "listItem",
@@ -196,6 +205,8 @@ const portableTextRender = (options: RenderOptions, isInline?: boolean) => {
     if (isPortableTextToolkitSpan(node)) {
       const UnknownComponent = components.unknownMark ?? UnknownMark;
 
+      cachedNodes.set(node, { Default: Mark, Unknown: UnknownComponent });
+
       return run(renderOptions.mark, {
         Component: provideComponent("mark", node.markType, UnknownComponent),
         props: asComponentProps(node, index, true),
@@ -208,6 +219,8 @@ const portableTextRender = (options: RenderOptions, isInline?: boolean) => {
       node.children = buildMarksTree(node);
 
       const UnknownComponent = components.unknownBlock ?? UnknownBlock;
+
+      cachedNodes.set(node, { Default: Block, Unknown: UnknownComponent });
 
       return run(renderOptions.block, {
         Component: provideComponent("block", node.style, UnknownComponent),
@@ -261,6 +274,11 @@ const portableTextRender = (options: RenderOptions, isInline?: boolean) => {
 
 // Returns the `default` component related to the passed in node
 const provideDefaultComponent = (node: TypedObject) => {
+  const DefaultComponent = cachedNodes.get(node)?.Default;
+
+  if (DefaultComponent) return DefaultComponent;
+  // Cache missed use manual lookup
+
   if (isPortableTextToolkitList(node)) return List;
   if (isPortableTextListItemBlock(node)) return ListItem;
   if (isPortableTextToolkitSpan(node)) return Mark;
@@ -275,6 +293,11 @@ const provideDefaultComponent = (node: TypedObject) => {
 
 // Returns the `unknown` component related to the passed in node
 const provideUnknownComponent = (node: TypedObject) => {
+  const UnknownComponent = cachedNodes.get(node)?.Unknown;
+
+  if (UnknownComponent) return UnknownComponent;
+  // Cache missed use manual lookup
+
   if (isPortableTextToolkitList(node)) {
     return components.unknownList ?? UnknownList;
   }

--- a/astro-portabletext/docs/types/README.md
+++ b/astro-portabletext/docs/types/README.md
@@ -28,3 +28,6 @@
 | [ListItem](type-aliases/ListItem.md) | Alias to [ToolkitPortableTextListItem](https://portabletext.github.io/toolkit/interfaces/ToolkitPortableTextListItem.html) |
 | [TextNode](type-aliases/TextNode.md) | Alias to [ToolkitTextNode](https://portabletext.github.io/toolkit/interfaces/ToolkitTextNode.html) |
 | [MissingComponentHandler](type-aliases/MissingComponentHandler.md) | The shape of the [onMissingComponent](interfaces/PortableTextProps.md#onMissingComponent) function |
+| [RenderHandlerProps](type-aliases/RenderHandlerProps.md) | Properties for the `RenderHandler` function |
+| [RenderHandler](type-aliases/RenderHandler.md) | The shape of the render component function |
+| [RenderOptions](type-aliases/RenderOptions.md) | Options for the `render` function accessed via `usePortableText` |

--- a/astro-portabletext/docs/types/type-aliases/RenderHandler.md
+++ b/astro-portabletext/docs/types/type-aliases/RenderHandler.md
@@ -1,0 +1,29 @@
+[**astro-portabletext**](../../README.md) • **Docs**
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / RenderHandler
+
+# Type Alias: RenderHandler()\<T, Children\>
+
+> **RenderHandler**\<`T`, `Children`\>: (`props`) => `any`
+
+The shape of the render component function
+
+## Type Parameters
+
+• **T** *extends* [`TypedObject`](../interfaces/TypedObject.md) = [`TypedObject`](../interfaces/TypedObject.md)
+
+Type of Portable Text payload
+
+• **Children** = `unknown`
+
+Type of children
+
+## Parameters
+
+• **props**: [`RenderHandlerProps`](RenderHandlerProps.md)\<`T`, `Children`\>
+
+## Returns
+
+`any`

--- a/astro-portabletext/docs/types/type-aliases/RenderHandlerProps.md
+++ b/astro-portabletext/docs/types/type-aliases/RenderHandlerProps.md
@@ -1,0 +1,33 @@
+[**astro-portabletext**](../../README.md) • **Docs**
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / RenderHandlerProps
+
+# Type Alias: RenderHandlerProps\<T, Children\>
+
+> **RenderHandlerProps**\<`T`, `Children`\>: `object`
+
+Properties for the `RenderHandler` function
+
+## Type Parameters
+
+• **T** *extends* [`TypedObject`](../interfaces/TypedObject.md) = [`TypedObject`](../interfaces/TypedObject.md)
+
+• **Children** = `unknown`
+
+## Type declaration
+
+### Component
+
+> **Component**: `Component`\<`T`\>
+
+The component to be rendered. This is a function that takes props and returns a rendered output
+
+### props
+
+> **props**: [`Props`](../interfaces/Props.md)\<`T`\>
+
+### children?
+
+> `optional` **children**: `Children`

--- a/astro-portabletext/docs/types/type-aliases/RenderOptions.md
+++ b/astro-portabletext/docs/types/type-aliases/RenderOptions.md
@@ -1,0 +1,41 @@
+[**astro-portabletext**](../../README.md) • **Docs**
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / RenderOptions
+
+# Type Alias: RenderOptions
+
+> **RenderOptions**: `object`
+
+Options for the `render` function accessed via `usePortableText`
+
+## Type declaration
+
+### default?
+
+> `optional` **default**: [`RenderHandler`](RenderHandler.md)
+
+### type?
+
+> `optional` **type**: [`RenderHandler`](RenderHandler.md)\<[`TypedObject`](../interfaces/TypedObject.md), `never`\>
+
+### block?
+
+> `optional` **block**: [`RenderHandler`](RenderHandler.md)\<[`Block`](../interfaces/Block.md)\>
+
+### list?
+
+> `optional` **list**: [`RenderHandler`](RenderHandler.md)\<[`List`](List.md)\>
+
+### listItem?
+
+> `optional` **listItem**: [`RenderHandler`](RenderHandler.md)\<[`ListItem`](ListItem.md)\>
+
+### mark?
+
+> `optional` **mark**: [`RenderHandler`](RenderHandler.md)\<[`Mark`](../interfaces/Mark.md)\>
+
+### text?
+
+> `optional` **text**: [`RenderHandler`](RenderHandler.md)\<[`TextNode`](TextNode.md), `never`\>

--- a/astro-portabletext/lib/context.ts
+++ b/astro-portabletext/lib/context.ts
@@ -1,9 +1,19 @@
 import type { TypedObject } from "@portabletext/types";
 import type { Component } from "./internal";
+import type { RenderOptions } from "./types";
 
+/**
+ * Context object providing access to rendering utilities within a Portable Text tree.
+ *
+ * @property getDefaultComponent - Function to retrieve the default astro-portabletext component associated with a node, such as `Block`, `List`, etc.
+ * @property getUnknownComponent - Function to retrieve the unknown component associated with a node, such as `unknownBlock`, `unknownList`, etc.
+ * @property render - Function to customize the rendering of specific node types.
+ */
 export interface Context {
   getDefaultComponent: () => Component;
   getUnknownComponent: () => Component;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (options: RenderOptions) => any;
 }
 
 export const key = Symbol("astro-portabletext");

--- a/astro-portabletext/lib/types.ts
+++ b/astro-portabletext/lib/types.ts
@@ -227,3 +227,43 @@ export type MissingComponentHandler = (
   message: string,
   context: { type: string; nodeType: NodeType }
 ) => void;
+
+/**
+ * Properties for the `RenderHandler` function
+ */
+export type RenderHandlerProps<
+  T extends TypedObject = TypedObject,
+  Children = unknown,
+> = {
+  /**
+   * The component to be rendered. This is a function that takes props and returns a rendered output
+   */
+  Component: Component<T>;
+  props: Props<T>;
+  children?: Children;
+};
+
+/**
+ * The shape of the render component function
+ *
+ * @typeParam T - Type of Portable Text payload
+ * @typeParam Children - Type of children
+ */
+export type RenderHandler<
+  T extends TypedObject = TypedObject,
+  Children = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+> = (props: RenderHandlerProps<T, Children>) => any;
+
+/**
+ * Options for the `render` function accessed via `usePortableText`
+ */
+export type RenderOptions = {
+  type?: RenderHandler<TypedObject, never>;
+  block?: RenderHandler<Block>;
+  list?: RenderHandler<List>;
+  listItem?: RenderHandler<ListItem>;
+  mark?: RenderHandler<Mark>;
+  text?: RenderHandler<TextNode, never>;
+  hardBreak?: RenderHandler<TextNode, never>;
+};

--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -48,5 +48,8 @@
   "dependencies": {
     "@portabletext/toolkit": "^2.0.16",
     "@portabletext/types": "^2.0.13"
+  },
+  "peerDependencies": {
+    "astro": ">=4.6.0"
   }
 }

--- a/lab/src/components/BlockWithBanner.astro
+++ b/lab/src/components/BlockWithBanner.astro
@@ -1,0 +1,26 @@
+---
+import type { Block, Props as $ } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+export type Props = $<Block>;
+
+const props = Astro.props;
+const { node, index, isInline, ...attrs } = props;
+const styleIs = (style: string) => style === node.style;
+
+const { getDefaultComponent } = usePortableText(node);
+
+const Default = getDefaultComponent();
+---
+
+{
+  styleIs("banner") ? (
+    <div class="banner" {...attrs}>
+      <slot />
+    </div>
+  ) : (
+    <Default {...props}>
+      <slot />
+    </Default>
+  )
+}

--- a/lab/src/components/BlockWithRender.astro
+++ b/lab/src/components/BlockWithRender.astro
@@ -1,0 +1,19 @@
+---
+import type { Block, Props as $ } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+export type Props = $<Block>;
+
+const props = Astro.props;
+const { node } = props;
+
+const { render } = usePortableText(node);
+---
+
+<div data-custom="block">
+  {
+    render({
+      text: ({ props }) => <span data-custom="text">{props.node.text} 🚀</span>,
+    })
+  }
+</div>

--- a/lab/src/components/HelloWorld.astro
+++ b/lab/src/components/HelloWorld.astro
@@ -1,5 +1,5 @@
 ---
-const { isInline } = Astro.props;
+const { node, isInline, index, ...attrs } = Astro.props;
 ---
 
-{isInline ? <span>Hello World</span> : <p>Hello World</p>}
+{isInline ? <span {...attrs}>Hello World</span> : <p {...attrs}>Hello World</p>}

--- a/lab/src/components/ListItem.astro
+++ b/lab/src/components/ListItem.astro
@@ -1,0 +1,11 @@
+---
+import type { Props as $, ListItem } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+type Props = $<ListItem>;
+
+const { getDefaultComponent } = usePortableText(Astro.props.node);
+const Li = getDefaultComponent();
+---
+
+<Li {...Astro.props}><slot /></Li>

--- a/lab/src/components/ListWithRender.astro
+++ b/lab/src/components/ListWithRender.astro
@@ -19,6 +19,8 @@ const Default = getDefaultComponent();
       })}
     </ul>
   ) : (
-    <Default {...Astro.props} />
+    <Default {...Astro.props}>
+      <slot />
+    </Default>
   )
 }

--- a/lab/src/components/ListWithRender.astro
+++ b/lab/src/components/ListWithRender.astro
@@ -1,0 +1,24 @@
+---
+import type { List, Props as $ } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+export type Props = $<List>;
+
+const { node, index, isInline, ...attrs } = Astro.props;
+const listItemIs = (listItem: string) => listItem === node.listItem;
+const { render, getDefaultComponent } = usePortableText(node);
+
+const Default = getDefaultComponent();
+---
+
+{
+  listItemIs("bullet") ? (
+    <ul {...attrs} data-custom="list">
+      {render({
+        text: ({ props }) => <span data-custom="text">{props.node.text}</span>,
+      })}
+    </ul>
+  ) : (
+    <Default {...Astro.props} />
+  )
+}

--- a/lab/src/components/Mark.astro
+++ b/lab/src/components/Mark.astro
@@ -1,0 +1,11 @@
+---
+import type { Props as $, Mark } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+type Props = $<Mark>;
+
+const { getDefaultComponent } = usePortableText(Astro.props.node);
+const Mrk = getDefaultComponent();
+---
+
+<Mrk {...Astro.props}><slot /></Mrk>

--- a/lab/src/components/MarkWithRender.astro
+++ b/lab/src/components/MarkWithRender.astro
@@ -20,6 +20,8 @@ const Default = getDefaultComponent();
       })}
     </em>
   ) : (
-    <Default {...Astro.props} />
+    <Default {...Astro.props}>
+      <slot />
+    </Default>
   )
 }

--- a/lab/src/components/MarkWithRender.astro
+++ b/lab/src/components/MarkWithRender.astro
@@ -1,0 +1,25 @@
+---
+import type { Mark, Props as $ } from "astro-portabletext/types";
+import { usePortableText } from "astro-portabletext/utils";
+
+export type Props = $<Mark>;
+
+const { node, index, isInline, ...attrs } = Astro.props;
+const markTypeIs = (markType: string) => markType === node.markType;
+
+const { getDefaultComponent, render } = usePortableText(node);
+
+const Default = getDefaultComponent();
+---
+
+{
+  markTypeIs("em") ? (
+    <em {...attrs}>
+      {render({
+        text: ({ props }) => <span data-custom="text">{props.node.text}</span>,
+      })}
+    </em>
+  ) : (
+    <Default {...Astro.props} />
+  )
+}

--- a/lab/src/components/MyBlock.astro
+++ b/lab/src/components/MyBlock.astro
@@ -9,4 +9,6 @@ const { getDefaultComponent } = usePortableText(props.node);
 const Default = getDefaultComponent();
 ---
 
-<Default {...props} />
+<Default {...props}>
+  <slot />
+</Default>

--- a/lab/src/pages/list/styled.astro
+++ b/lab/src/pages/list/styled.astro
@@ -1,0 +1,24 @@
+---
+import { PortableText } from "astro-portabletext";
+import Layout from "../../layouts/Default.astro";
+import BlockWithBanner from "../../components/BlockWithBanner.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    listItem: "bullet",
+    level: 1,
+    style: "banner",
+    children: [
+      {
+        _type: "span",
+        text: "List Item 1",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ block: BlockWithBanner }} />
+</Layout>

--- a/lab/src/pages/render/block.astro
+++ b/lab/src/pages/render/block.astro
@@ -1,0 +1,22 @@
+---
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import BlockWithRender from "../../components/BlockWithRender.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    style: "normal",
+    children: [
+      {
+        _type: "span",
+        text: "Rocket launch",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ block: BlockWithRender }} />
+</Layout>

--- a/lab/src/pages/render/list.astro
+++ b/lab/src/pages/render/list.astro
@@ -1,0 +1,22 @@
+---
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import ListWithRender from "../../components/ListWithRender.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    listItem: "bullet",
+    children: [
+      {
+        _type: "span",
+        text: "List Item 1",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ list: ListWithRender }} />
+</Layout>

--- a/lab/src/pages/render/mark.astro
+++ b/lab/src/pages/render/mark.astro
@@ -1,0 +1,22 @@
+---
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import MarkWithRender from "../../components/MarkWithRender.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    children: [
+      {
+        _type: "span",
+        text: "emphasize",
+        marks: ["em"],
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ mark: MarkWithRender }} />
+</Layout>

--- a/lab/src/pages/slot/block-custom.astro
+++ b/lab/src/pages/slot/block-custom.astro
@@ -1,0 +1,37 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import MyBlock from "../../components/MyBlock.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    style: "normal",
+    children: [
+      {
+        _type: "span",
+        text: "I'm a paragraph",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ block: MyBlock }}>
+    <fragment slot="block">
+      {
+        ({ Component, props, children }) => {
+          assert(Component === MyBlock, "Component is not MyBlock");
+
+          return (
+            <Component {...props} data-slot="custom-block">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/block.astro
+++ b/lab/src/pages/slot/block.astro
@@ -1,0 +1,37 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import { Block as DefaultBlock } from "astro-portabletext/components";
+
+const blocks = [
+  {
+    _type: "block",
+    style: "normal",
+    children: [
+      {
+        _type: "span",
+        text: "I'm a paragraph",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks}>
+    <fragment slot="block">
+      {
+        ({ Component, props, children }) => {
+          assert(Component === DefaultBlock, "Component is not DefaultBlock");
+
+          return (
+            <Component {...props} data-slot="block">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/list-custom.astro
+++ b/lab/src/pages/slot/list-custom.astro
@@ -1,0 +1,40 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import ListWithRender from "../../components/ListWithRender.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    listItem: "bullet",
+    children: [
+      {
+        _type: "span",
+        text: "List Item 1",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ list: ListWithRender }}>
+    <fragment slot="list">
+      {
+        ({ Component, props, children }) => {
+          assert(
+            Component === ListWithRender,
+            "Component is not ListWithRender"
+          );
+
+          return (
+            <Component {...props} data-slot="custom-list">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/list.astro
+++ b/lab/src/pages/slot/list.astro
@@ -1,0 +1,37 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import { List as DefaultList } from "astro-portabletext/components";
+
+const blocks = [
+  {
+    _type: "block",
+    listItem: "bullet",
+    children: [
+      {
+        _type: "span",
+        text: "List Item 1",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks}>
+    <fragment slot="list">
+      {
+        ({ Component, props, children }) => {
+          assert(Component === DefaultList, "Component is not DefaultList");
+
+          return (
+            <Component {...props} data-slot="list">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/listitem-custom.astro
+++ b/lab/src/pages/slot/listitem-custom.astro
@@ -1,0 +1,37 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import ListItem from "../../components/ListItem.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    listItem: "bullet",
+    children: [
+      {
+        _type: "span",
+        text: "List Item 1",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ listItem: ListItem }}>
+    <fragment slot="listItem">
+      {
+        ({ Component, props, children }) => {
+          assert(Component === ListItem, "Component is not ListItem");
+
+          return (
+            <Component {...props} data-slot="custom-listitem">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/listitem.astro
+++ b/lab/src/pages/slot/listitem.astro
@@ -1,0 +1,40 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import { ListItem as DefaultListItem } from "astro-portabletext/components";
+
+const blocks = [
+  {
+    _type: "block",
+    listItem: "bullet",
+    children: [
+      {
+        _type: "span",
+        text: "List Item 1",
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks}>
+    <fragment slot="listItem">
+      {
+        ({ Component, props, children }) => {
+          assert(
+            Component === DefaultListItem,
+            "Component is not DefaultListItem"
+          );
+
+          return (
+            <Component {...props} data-slot="listitem">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/mark-custom.astro
+++ b/lab/src/pages/slot/mark-custom.astro
@@ -1,0 +1,37 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import Mark from "../../components/Mark.astro";
+
+const blocks = [
+  {
+    _type: "block",
+    children: [
+      {
+        _type: "span",
+        text: "bold",
+        marks: ["strong"],
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks} components={{ mark: Mark }}>
+    <fragment slot="mark">
+      {
+        ({ Component, props, children }) => {
+          assert(Component === Mark, "Component is not Mark");
+
+          return (
+            <Component {...props} data-slot="custom-mark">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/mark.astro
+++ b/lab/src/pages/slot/mark.astro
@@ -1,0 +1,37 @@
+---
+import assert from "node:assert";
+import Layout from "../../layouts/Default.astro";
+import { PortableText } from "astro-portabletext";
+import { Mark as DefaultMark } from "astro-portabletext/components";
+
+const blocks = [
+  {
+    _type: "block",
+    children: [
+      {
+        _type: "span",
+        text: "bold",
+        marks: ["strong"],
+      },
+    ],
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks}>
+    <fragment slot="mark">
+      {
+        ({ Component, props, children }) => {
+          assert(Component === DefaultMark, "Component is not DefaultMark");
+
+          return (
+            <Component {...props} data-slot="mark">
+              {children}
+            </Component>
+          );
+        }
+      }
+    </fragment>
+  </PortableText>
+</Layout>

--- a/lab/src/pages/slot/type.astro
+++ b/lab/src/pages/slot/type.astro
@@ -1,0 +1,30 @@
+---
+import assert from "node:assert";
+import { PortableText } from "astro-portabletext";
+import UnknownType from "../../../../astro-portabletext/components/UnknownType.astro";
+import Layout from "../../layouts/Default.astro";
+
+const blocks = [
+  {
+    _type: "helloWorld",
+  },
+];
+---
+
+<Layout>
+  <PortableText value={blocks}>
+    <fragment slot="type"
+      >{
+        ({ Component, props }) => {
+          assert(Component === UnknownType, "Component is not UnknownType");
+
+          switch (props.node._type) {
+            case "helloWorld":
+              return <div data-slot="type">Hello World</div>;
+          }
+          return <Component {...props} />;
+        }
+      }</fragment
+    >
+  </PortableText>
+</Layout>

--- a/lab/src/test/list.test.js
+++ b/lab/src/test/list.test.js
@@ -42,4 +42,20 @@ list("nested", async () => {
   );
 });
 
+list("styled", async () => {
+  const $ = await fetchContent("list/styled");
+  const $ul = $("ul");
+
+  assert.is($ul.length, 1);
+
+  const $li = $ul.find("li");
+
+  assert.is($li.length, 1);
+
+  const $banner = $li.find("div.banner");
+
+  assert.is($banner.length, 1);
+  assert.is($banner.text(), "List Item 1");
+});
+
 list.run();

--- a/lab/src/test/render.test.js
+++ b/lab/src/test/render.test.js
@@ -1,0 +1,35 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+import { fetchContent } from "../utils.mjs";
+
+const render = suite("render");
+
+render("block", async () => {
+  const $ = await fetchContent("render/block");
+  const $block = $("div[data-custom='block']");
+  const $span = $block.find("span[data-custom='text']");
+
+  assert.is($block.length, 1);
+  assert.is($span.length, 1);
+  assert.is($span.text(), "Rocket launch 🚀");
+});
+
+render("list", async () => {
+  const $ = await fetchContent("render/list");
+  const $list = $("ul[data-custom='list']");
+  const $span = $list.find("span[data-custom='text']");
+
+  assert.is($list.length, 1);
+  assert.is($span.length, 1);
+});
+
+render("mark", async () => {
+  const $ = await fetchContent("render/mark");
+  const $em = $("em");
+  const $span = $em.find("span[data-custom='text']");
+
+  assert.is($em.length, 1);
+  assert.is($span.length, 1);
+});
+
+render.run();

--- a/lab/src/test/slot.test.js
+++ b/lab/src/test/slot.test.js
@@ -11,9 +11,23 @@ slot("block", async () => {
   assert.is($el.length, 1);
 });
 
+slot("custom block", async () => {
+  const $ = await fetchContent("slot/block-custom");
+  const $el = $("p[data-slot='custom-block']");
+
+  assert.is($el.length, 1);
+});
+
 slot("list", async () => {
   const $ = await fetchContent("slot/list");
   const $el = $("ul[data-slot='list']");
+
+  assert.is($el.length, 1);
+});
+
+slot("custom list", async () => {
+  const $ = await fetchContent("slot/list-custom");
+  const $el = $("ul[data-slot='custom-list']");
 
   assert.is($el.length, 1);
 });
@@ -25,11 +39,27 @@ slot("listitem", async () => {
   assert.is($el.length, 1);
 });
 
+slot("custom listitem", async () => {
+  const $ = await fetchContent("slot/listitem-custom");
+  const $el = $("li[data-slot='custom-listitem']");
+
+  assert.is($el.length, 1);
+  assert.is($el.text(), "List Item 1");
+});
+
 slot("mark", async () => {
   const $ = await fetchContent("slot/mark");
   const $el = $("strong[data-slot='mark']");
 
   assert.is($el.length, 1);
+});
+
+slot("custom mark", async () => {
+  const $ = await fetchContent("slot/mark-custom");
+  const $el = $("strong[data-slot='custom-mark']");
+
+  assert.is($el.length, 1);
+  assert.is($el.text(), "bold");
 });
 
 slot("type", async () => {

--- a/lab/src/test/slot.test.js
+++ b/lab/src/test/slot.test.js
@@ -1,0 +1,43 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+import { fetchContent } from "../utils.mjs";
+
+const slot = suite("extras");
+
+slot("block", async () => {
+  const $ = await fetchContent("slot/block");
+  const $el = $("p[data-slot='block']");
+
+  assert.is($el.length, 1);
+});
+
+slot("list", async () => {
+  const $ = await fetchContent("slot/list");
+  const $el = $("ul[data-slot='list']");
+
+  assert.is($el.length, 1);
+});
+
+slot("listitem", async () => {
+  const $ = await fetchContent("slot/listitem");
+  const $el = $("li[data-slot='listitem']");
+
+  assert.is($el.length, 1);
+});
+
+slot("mark", async () => {
+  const $ = await fetchContent("slot/mark");
+  const $el = $("strong[data-slot='mark']");
+
+  assert.is($el.length, 1);
+});
+
+slot("type", async () => {
+  const $ = await fetchContent("slot/type");
+  const $el = $("[data-slot='type']");
+
+  assert.is($el.length, 1);
+  assert.is($el.text(), "Hello World");
+});
+
+slot.run();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@portabletext/types':
         specifier: ^2.0.13
         version: 2.0.13
+      astro:
+        specifier: '>=4.6.0'
+        version: 4.12.2(@types/node@20.14.12)(typescript@5.5.4)
 
   demo:
     dependencies:


### PR DESCRIPTION
This feature introduces new customisation options for fine-tuning the rendering of Portable Text content.

⚠️ This feature requires Astro v4.6.0+ for compatibility due to issues with slots in earlier versions.

**Changes Made:**

- Enabled the use of `slots` in the `PortableText` component. Users can now use Astro's slot syntax to modify the rendering of specific elements, providing more control over the overall structure and layout. The `slot` name options are `type`, `block`, `list`, `listItem`, `mark`, `text` and `hardBreak`.

  In the example below, `CustomBlock` is passed in to `components.block` option and when using `slots` it will be passed in as the `Component` prop to further enhance the output. If no custom block component is defined, `Component` will be `astro-portabletext` block component.

```js
/* .astro */
---
import { PortableText } from "astro-portabletext";
import CustomBlock from "./CustomBlock.astro";

const portableText = [
  {
    _type: 'block',
    _key: 'a1ph4',
    style: 'normal',
    markDefs: [],
    children: [
      {
        _type: 'span',
        _key: 'c961f',
        text: 'This is a Portable Text example.',
        marks: [],
      },
    ],
  },
];
---

<PortableText value={ portableText } components={{ block: CustomBlock }}>

  <fragment slot="block">{({ Component /* CustomBlock */, props, children }) => (
    <Component {...props} class="block">{children}</Component>
  )}</fragment>

</PortableText>

<style>
  .block:where(h1, h2) {
    /* some styles */
  }
</style>
```

- Added a `render` function to `usePortableText`. This function allows users to customise the output of child nodes, such as modifying text content, changing how links are rendered, or conditionally rendering elements.

```ts
/* CustomBlock.astro */
---
import type { Block, Props as $ } from "astro-portabletext/types";
import { usePortableText } from "astro-portabletext/utils";

export type Props = $<Block>;

const { node, isInline, index, ...attrs} = Astro.props;
const { render, getDefaultComponent } = usePortableText(node);

const DefaultBlock = getDefaultComponent(); // In this `block` context, it returns `astro-portabletext` block component

const styleIs = (style: string) => style === node.style;
---

{
  styleIs("h1") ? (
    <h1 {...attrs}>{render({
      text: ({ props }) => props.node.text.replace("fox", "🦊") // Use the render function to customise the output
    })}</h1>
  ) : (
    <DefaultBlock {...Astro.props}>
      <slot />
    </DefaultBlock>
  )
}
```

Closes #158 