### PR TITLE
feat(lib): consolidate exports and improve library organisation

### DIFF
--- a/astro-portabletext/components/PortableText.astro
+++ b/astro-portabletext/components/PortableText.astro
@@ -11,7 +11,10 @@ import {
 } from "@portabletext/toolkit";
 
 import type {
+  Component,
+  Context,
   MissingComponentHandler,
+  NodeType,
   PortableTextComponents,
   PortableTextProps,
   Props as ComponentProps,
@@ -19,15 +22,10 @@ import type {
   TypedObject,
 } from "../lib/types";
 
-import {
-  isComponent,
-  mergeComponents,
-  type Component,
-  type NodeType,
-} from "../lib/internal";
+import { isComponent, mergeComponents } from "../lib/internal";
 
 import { getWarningMessage, printWarning } from "../lib/warnings";
-import { key as contextRef, type Context } from "../lib/context";
+import { key as contextRef } from "../lib/context";
 
 import Block from "./Block.astro";
 import HardBreak from "./HardBreak.astro";

--- a/astro-portabletext/docs/types/README.md
+++ b/astro-portabletext/docs/types/README.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../README.md) • **Docs**
+[**astro-portabletext**](../README.md)
 
 ***
 
@@ -17,6 +17,7 @@
 | [Props](interfaces/Props.md) | Component Props |
 | [Block](interfaces/Block.md) | Alias to [PortableTextBlock](https://portabletext.github.io/types/interfaces/PortableTextBlock.html) with `style` set to `normal` |
 | [Mark](interfaces/Mark.md) | Extends [ToolkitNestedPortableTextSpan](https://portabletext.github.io/toolkit/interfaces/ToolkitNestedPortableTextSpan.html) with consisting `markDef` and `markKey` properties |
+| [Context](interfaces/Context.md) | Context object providing access to rendering utilities within a Portable Text tree. |
 | [TypedObject](interfaces/TypedObject.md) | Any object with an `_type` property (which is required in portable text arrays), as well as a _potential_ `_key` (highly encouraged) |
 
 ### Type Aliases
@@ -31,3 +32,6 @@
 | [RenderHandlerProps](type-aliases/RenderHandlerProps.md) | Properties for the `RenderHandler` function |
 | [RenderHandler](type-aliases/RenderHandler.md) | The shape of the render component function |
 | [RenderOptions](type-aliases/RenderOptions.md) | Options for the `render` function accessed via `usePortableText` |
+| [Component](type-aliases/Component.md) | Generic Portable Text component |
+| [ComponentOrRecord](type-aliases/ComponentOrRecord.md) | For internal use |
+| [NodeType](type-aliases/NodeType.md) | - |

--- a/astro-portabletext/docs/types/interfaces/Block.md
+++ b/astro-portabletext/docs/types/interfaces/Block.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/interfaces/Context.md
+++ b/astro-portabletext/docs/types/interfaces/Context.md
@@ -1,0 +1,51 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / Context
+
+# Interface: Context
+
+Context object providing access to rendering utilities within a Portable Text tree.
+
+## Properties
+
+### getDefaultComponent()
+
+> **getDefaultComponent**: () => [`Component`](../type-aliases/Component.md)\<`any`\>
+
+Function to retrieve the default astro-portabletext component associated with a node, such as `Block`, `List`, etc.
+
+#### Returns
+
+[`Component`](../type-aliases/Component.md)\<`any`\>
+
+***
+
+### getUnknownComponent()
+
+> **getUnknownComponent**: () => [`Component`](../type-aliases/Component.md)\<`any`\>
+
+Function to retrieve the unknown component associated with a node, such as `unknownBlock`, `unknownList`, etc.
+
+#### Returns
+
+[`Component`](../type-aliases/Component.md)\<`any`\>
+
+***
+
+### render()
+
+> **render**: (`options`) => `any`
+
+Function to customize the rendering of specific node types.
+
+#### Parameters
+
+##### options
+
+[`RenderOptions`](../type-aliases/RenderOptions.md)
+
+#### Returns
+
+`any`

--- a/astro-portabletext/docs/types/interfaces/Mark.md
+++ b/astro-portabletext/docs/types/interfaces/Mark.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/interfaces/PortableTextComponents.md
+++ b/astro-portabletext/docs/types/interfaces/PortableTextComponents.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -12,7 +12,7 @@ Object defining how Portable Text types should be rendered
 
 ### type
 
-> **type**: `ComponentOrRecord`
+> **type**: [`ComponentOrRecord`](../type-aliases/ComponentOrRecord.md)\<`any`\>
 
 How user-defined types should be rendered
 
@@ -20,7 +20,7 @@ How user-defined types should be rendered
 
 ### unknownType
 
-> **unknownType**: `Component`
+> **unknownType**: [`Component`](../type-aliases/Component.md)\<`any`\>
 
 Used when a [type](PortableTextComponents.md#type) component isn't found
 
@@ -28,7 +28,7 @@ Used when a [type](PortableTextComponents.md#type) component isn't found
 
 ### block
 
-> **block**: `ComponentOrRecord`\<[`Block`](Block.md)\>
+> **block**: [`ComponentOrRecord`](../type-aliases/ComponentOrRecord.md)\<[`Block`](Block.md)\>
 
 How blocks should be rendered
 
@@ -36,7 +36,7 @@ How blocks should be rendered
 
 ### unknownBlock
 
-> **unknownBlock**: `Component`\<[`Block`](Block.md)\>
+> **unknownBlock**: [`Component`](../type-aliases/Component.md)\<[`Block`](Block.md)\>
 
 Used when a [block](PortableTextComponents.md#block) component isn't found
 
@@ -44,7 +44,7 @@ Used when a [block](PortableTextComponents.md#block) component isn't found
 
 ### list
 
-> **list**: `ComponentOrRecord`\<`ToolkitPortableTextList`\>
+> **list**: [`ComponentOrRecord`](../type-aliases/ComponentOrRecord.md)\<`ToolkitPortableTextList`\>
 
 How lists should be rendered
 
@@ -52,7 +52,7 @@ How lists should be rendered
 
 ### unknownList
 
-> **unknownList**: `Component`\<`ToolkitPortableTextList`\>
+> **unknownList**: [`Component`](../type-aliases/Component.md)\<`ToolkitPortableTextList`\>
 
 Used when a [list](PortableTextComponents.md#list) component isn't found
 
@@ -60,7 +60,7 @@ Used when a [list](PortableTextComponents.md#list) component isn't found
 
 ### listItem
 
-> **listItem**: `ComponentOrRecord`\<`ToolkitPortableTextListItem`\>
+> **listItem**: [`ComponentOrRecord`](../type-aliases/ComponentOrRecord.md)\<`ToolkitPortableTextListItem`\>
 
 How list items should be rendered
 
@@ -68,7 +68,7 @@ How list items should be rendered
 
 ### unknownListItem
 
-> **unknownListItem**: `Component`\<`ToolkitPortableTextListItem`\>
+> **unknownListItem**: [`Component`](../type-aliases/Component.md)\<`ToolkitPortableTextListItem`\>
 
 Used when a [listItem](PortableTextComponents.md#listItem) component isn't found
 
@@ -76,7 +76,7 @@ Used when a [listItem](PortableTextComponents.md#listItem) component isn't found
 
 ### mark
 
-> **mark**: `ComponentOrRecord`\<[`Mark`](Mark.md)\<`never`\>\>
+> **mark**: [`ComponentOrRecord`](../type-aliases/ComponentOrRecord.md)\<[`Mark`](Mark.md)\<`never`\>\>
 
 How marked text should be rendered
 
@@ -84,7 +84,7 @@ How marked text should be rendered
 
 ### unknownMark
 
-> **unknownMark**: `Component`\<[`Mark`](Mark.md)\<`never`\>\>
+> **unknownMark**: [`Component`](../type-aliases/Component.md)\<[`Mark`](Mark.md)\<`never`\>\>
 
 Used when a [mark](PortableTextComponents.md#mark) component isn't found
 
@@ -92,7 +92,7 @@ Used when a [mark](PortableTextComponents.md#mark) component isn't found
 
 ### text
 
-> **text**: `Component`\<`ToolkitTextNode`\>
+> **text**: [`Component`](../type-aliases/Component.md)\<`ToolkitTextNode`\>
 
 How text should be rendered
 
@@ -100,6 +100,6 @@ How text should be rendered
 
 ### hardBreak
 
-> **hardBreak**: `Component`\<`ToolkitTextNode`\>
+> **hardBreak**: [`Component`](../type-aliases/Component.md)\<`ToolkitTextNode`\>
 
 How line breaks should be rendered

--- a/astro-portabletext/docs/types/interfaces/PortableTextProps.md
+++ b/astro-portabletext/docs/types/interfaces/PortableTextProps.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/interfaces/Props.md
+++ b/astro-portabletext/docs/types/interfaces/Props.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/interfaces/TypedObject.md
+++ b/astro-portabletext/docs/types/interfaces/TypedObject.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/type-aliases/Component.md
+++ b/astro-portabletext/docs/types/type-aliases/Component.md
@@ -1,0 +1,27 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / Component
+
+# Type Alias: Component()\<T\>
+
+> **Component**\<`T`\>: (`props`) => `any`
+
+**`Internal`**
+
+Generic Portable Text component
+
+## Type Parameters
+
+• **T** *extends* [`TypedObject`](../interfaces/TypedObject.md) = `any`
+
+## Parameters
+
+### props
+
+[`Props`](../interfaces/Props.md)\<`T`\>
+
+## Returns
+
+`any`

--- a/astro-portabletext/docs/types/type-aliases/ComponentOrRecord.md
+++ b/astro-portabletext/docs/types/type-aliases/ComponentOrRecord.md
@@ -1,0 +1,17 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / ComponentOrRecord
+
+# Type Alias: ComponentOrRecord\<T\>
+
+> **ComponentOrRecord**\<`T`\>: [`Component`](Component.md)\<`T`\> \| `Record`\<`string`, [`Component`](Component.md)\<`T`\>\>
+
+**`Internal`**
+
+For internal use
+
+## Type Parameters
+
+• **T** *extends* [`TypedObject`](../interfaces/TypedObject.md) = `any`

--- a/astro-portabletext/docs/types/type-aliases/List.md
+++ b/astro-portabletext/docs/types/type-aliases/List.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/type-aliases/ListItem.md
+++ b/astro-portabletext/docs/types/type-aliases/ListItem.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/type-aliases/MissingComponentHandler.md
+++ b/astro-portabletext/docs/types/type-aliases/MissingComponentHandler.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -12,13 +12,19 @@ The shape of the [onMissingComponent](../interfaces/PortableTextProps.md#onMissi
 
 ## Parameters
 
-• **message**: `string`
+### message
 
-• **context**
+`string`
 
-• **context.type**: `string`
+### context
 
-• **context.nodeType**: `NodeType`
+#### type
+
+`string`
+
+#### nodeType
+
+[`NodeType`](NodeType.md)
 
 ## Returns
 

--- a/astro-portabletext/docs/types/type-aliases/NodeType.md
+++ b/astro-portabletext/docs/types/type-aliases/NodeType.md
@@ -1,0 +1,11 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / NodeType
+
+# Type Alias: NodeType
+
+> **NodeType**: `"type"` \| `"block"` \| `"list"` \| `"listItem"` \| `"mark"`
+
+**`Internal`**

--- a/astro-portabletext/docs/types/type-aliases/RenderHandler.md
+++ b/astro-portabletext/docs/types/type-aliases/RenderHandler.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -22,7 +22,9 @@ Type of children
 
 ## Parameters
 
-• **props**: [`RenderHandlerProps`](RenderHandlerProps.md)\<`T`, `Children`\>
+### props
+
+[`RenderHandlerProps`](RenderHandlerProps.md)\<`T`, `Children`\>
 
 ## Returns
 

--- a/astro-portabletext/docs/types/type-aliases/RenderHandlerProps.md
+++ b/astro-portabletext/docs/types/type-aliases/RenderHandlerProps.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -20,7 +20,7 @@ Properties for the `RenderHandler` function
 
 ### Component
 
-> **Component**: `Component`\<`T`\>
+> **Component**: [`Component`](Component.md)\<`T`\>
 
 The component to be rendered. This is a function that takes props and returns a rendered output
 

--- a/astro-portabletext/docs/types/type-aliases/RenderOptions.md
+++ b/astro-portabletext/docs/types/type-aliases/RenderOptions.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/type-aliases/SomePortableTextComponents.md
+++ b/astro-portabletext/docs/types/type-aliases/SomePortableTextComponents.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/types/type-aliases/TextNode.md
+++ b/astro-portabletext/docs/types/type-aliases/TextNode.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 

--- a/astro-portabletext/docs/utils/README.md
+++ b/astro-portabletext/docs/utils/README.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../README.md) • **Docs**
+[**astro-portabletext**](../README.md)
 
 ***
 

--- a/astro-portabletext/docs/utils/functions/mergeComponents.md
+++ b/astro-portabletext/docs/utils/functions/mergeComponents.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -16,13 +16,17 @@ Helper to merge [SomePortableTextComponents](../../types/type-aliases/SomePortab
 
 • **Overrides** *extends* `Partial`\<[`PortableTextComponents`](../../types/interfaces/PortableTextComponents.md)\>
 
-• **MergedComponents** = \{ \[Key in string \| number \| symbol\]: Key extends keyof Components & keyof Overrides ? Overrides\[Key\<Key\>\] extends Component\<any\> ? any\[any\] : Components\[Key\<Key\>\] extends Component\<any\> ? Overrides\[Key\<Key\>\] : (Overrides & Components)\[Key\<Key\>\] : (Overrides & Components)\[Key\] \}
+• **MergedComponents** = \{ \[Key in string \| number \| symbol\]: Key extends keyof Components & keyof Overrides ? Overrides\[Key\<Key\>\] extends Component ? any\[any\] : Components\[Key\<Key\>\] extends Component ? Overrides\[Key\<Key\>\] : (Overrides & Components)\[Key\<Key\>\] : (Overrides & Components)\[Key\] \}
 
 ## Parameters
 
-• **components**: `Components`
+### components
 
-• **overrides**: `Overrides`
+`Components`
+
+### overrides
+
+`Overrides`
 
 ## Returns
 

--- a/astro-portabletext/docs/utils/functions/toPlainText.md
+++ b/astro-portabletext/docs/utils/functions/toPlainText.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -17,9 +17,11 @@ custom content types are not included in the output.
 
 ## Parameters
 
-• **block**: `PortableTextBlock`\<`PortableTextMarkDefinition`, `ArbitraryTypedObject` \| `PortableTextSpan`, `string`, `string`\> \| `ArbitraryTypedObject`[] \| `PortableTextBlock`\<`PortableTextMarkDefinition`, `ArbitraryTypedObject` \| `PortableTextSpan`, `string`, `string`\>[]
+### block
 
 Single block or an array of blocks to extract text from
+
+`PortableTextBlock`\<`PortableTextMarkDefinition`, `ArbitraryTypedObject` \| `PortableTextSpan`, `string`, `string`\> | `ArbitraryTypedObject`[] | `PortableTextBlock`\<`PortableTextMarkDefinition`, `ArbitraryTypedObject` \| `PortableTextSpan`, `string`, `string`\>[]
 
 ## Returns
 

--- a/astro-portabletext/docs/utils/functions/usePortableText.md
+++ b/astro-portabletext/docs/utils/functions/usePortableText.md
@@ -1,4 +1,4 @@
-[**astro-portabletext**](../../README.md) • **Docs**
+[**astro-portabletext**](../../README.md)
 
 ***
 
@@ -6,12 +6,14 @@
 
 # Function: usePortableText()
 
-> **usePortableText**(`node`): `Context`
+> **usePortableText**(`node`): [`Context`](../../types/interfaces/Context.md)
 
 ## Parameters
 
-• **node**: [`TypedObject`](../../types/interfaces/TypedObject.md)
+### node
+
+[`TypedObject`](../../types/interfaces/TypedObject.md)
 
 ## Returns
 
-`Context`
+[`Context`](../../types/interfaces/Context.md)

--- a/astro-portabletext/lib/context.ts
+++ b/astro-portabletext/lib/context.ts
@@ -1,20 +1,5 @@
 import type { TypedObject } from "@portabletext/types";
-import type { Component } from "./internal";
-import type { RenderOptions } from "./types";
-
-/**
- * Context object providing access to rendering utilities within a Portable Text tree.
- *
- * @property getDefaultComponent - Function to retrieve the default astro-portabletext component associated with a node, such as `Block`, `List`, etc.
- * @property getUnknownComponent - Function to retrieve the unknown component associated with a node, such as `unknownBlock`, `unknownList`, etc.
- * @property render - Function to customize the rendering of specific node types.
- */
-export interface Context {
-  getDefaultComponent: () => Component;
-  getUnknownComponent: () => Component;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: (options: RenderOptions) => any;
-}
+import type { Context } from "./types";
 
 export const key = Symbol("astro-portabletext");
 

--- a/astro-portabletext/lib/context.ts
+++ b/astro-portabletext/lib/context.ts
@@ -18,7 +18,7 @@ export interface Context {
 
 export const key = Symbol("astro-portabletext");
 
-export function useContext(node: TypedObject) {
+export function usePortableText(node: TypedObject) {
   if (!(key in globalThis)) {
     throw new Error(`PortableText "context" has not been initialised`);
   }

--- a/astro-portabletext/lib/index.ts
+++ b/astro-portabletext/lib/index.ts
@@ -1,1 +1,2 @@
 export { default as PortableText } from "../components/PortableText.astro";
+export * from "./utils";

--- a/astro-portabletext/lib/internal.ts
+++ b/astro-portabletext/lib/internal.ts
@@ -1,4 +1,8 @@
-import type { Props, SomePortableTextComponents, TypedObject } from "./types";
+import type {
+  Component,
+  ComponentOrRecord,
+  SomePortableTextComponents,
+} from "./types";
 
 /**
  * Helper for component to throw an error
@@ -52,24 +56,3 @@ export function mergeComponents<
 
   return cmps as MergedComponents;
 }
-
-/**
- * Generic Portable Text component
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Component<T extends TypedObject = any> = (props: Props<T>) => any;
-
-/**
- * For internal use
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ComponentOrRecord<T extends TypedObject = any> =
-  | Component<T>
-  | Record<string, Component<T>>;
-
-/**
- * @internal
- */
-export type NodeType = "type" | "block" | "list" | "listItem" | "mark";

--- a/astro-portabletext/lib/types.ts
+++ b/astro-portabletext/lib/types.ts
@@ -14,8 +14,6 @@ import type {
   TypedObject,
 } from "@portabletext/types";
 
-import type { Component, ComponentOrRecord, NodeType } from "./internal";
-
 export type { TypedObject } from "@portabletext/types";
 
 /**
@@ -267,3 +265,38 @@ export type RenderOptions = {
   text?: RenderHandler<TextNode, never>;
   hardBreak?: RenderHandler<TextNode, never>;
 };
+
+/**
+ * Context object providing access to rendering utilities within a Portable Text tree.
+ *
+ * @property getDefaultComponent - Function to retrieve the default astro-portabletext component associated with a node, such as `Block`, `List`, etc.
+ * @property getUnknownComponent - Function to retrieve the unknown component associated with a node, such as `unknownBlock`, `unknownList`, etc.
+ * @property render - Function to customize the rendering of specific node types.
+ */
+export interface Context {
+  getDefaultComponent: () => Component;
+  getUnknownComponent: () => Component;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (options: RenderOptions) => any;
+}
+
+/**
+ * Generic Portable Text component
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Component<T extends TypedObject = any> = (props: Props<T>) => any;
+
+/**
+ * For internal use
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ComponentOrRecord<T extends TypedObject = any> =
+  | Component<T>
+  | Record<string, Component<T>>;
+
+/**
+ * @internal
+ */
+export type NodeType = "type" | "block" | "list" | "listItem" | "mark";

--- a/astro-portabletext/lib/utils.d.ts
+++ b/astro-portabletext/lib/utils.d.ts
@@ -1,0 +1,20 @@
+declare module "astro-portabletext/utils" {
+  /**
+   * @deprecated Use `toPlainText` from `astro-portabletext` instead
+   */
+  export function toPlainText(
+    ...args: Parameters<typeof import("@portabletext/toolkit").toPlainText>
+  ): ReturnType<typeof import("@portabletext/toolkit").toPlainText>;
+  /**
+   * @deprecated Use `mergeComponents` from `astro-portabletext` instead
+   */
+  export function mergeComponents(
+    ...args: Parameters<typeof import("./utils").mergeComponents>
+  ): ReturnType<typeof import("./utils").mergeComponents>;
+  /**
+   * @deprecated Use `usePortableText` from `astro-portabletext` instead
+   */
+  export function usePortableText(
+    ...args: Parameters<typeof import("./utils").usePortableText>
+  ): ReturnType<typeof import("./utils").usePortableText>;
+}

--- a/astro-portabletext/lib/utils.ts
+++ b/astro-portabletext/lib/utils.ts
@@ -1,3 +1,3 @@
 export { toPlainText } from "@portabletext/toolkit";
 export { mergeComponents } from "./internal";
-export { useContext as usePortableText } from "./context";
+export { usePortableText } from "./context";

--- a/astro-portabletext/lib/warnings.ts
+++ b/astro-portabletext/lib/warnings.ts
@@ -1,4 +1,4 @@
-import type { NodeType } from "./internal";
+import type { NodeType } from "./types";
 
 const getTemplate = (prop: string, type: string): string =>
   `PortableText [components.${prop}] is missing "${type}"`;

--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -17,7 +17,11 @@
     ".": "./lib/index.ts",
     "./components": "./lib/components.ts",
     "./types": "./lib/types.ts",
-    "./utils": "./lib/utils.ts"
+    "./utils": {
+      "types": "./lib/utils.d.ts",
+      "import": "./lib/utils.ts",
+      "default": "./lib/utils.ts"
+    }
   },
   "typesVersions": {
     "*": {

--- a/lab/src/components/BlockIndex.astro
+++ b/lab/src/components/BlockIndex.astro
@@ -1,6 +1,6 @@
 ---
 import type { Block, Props as $ } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 export type Props = $<Block>;
 

--- a/lab/src/components/BlockWithBanner.astro
+++ b/lab/src/components/BlockWithBanner.astro
@@ -1,6 +1,6 @@
 ---
 import type { Block, Props as $ } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 export type Props = $<Block>;
 

--- a/lab/src/components/BlockWithRender.astro
+++ b/lab/src/components/BlockWithRender.astro
@@ -1,6 +1,6 @@
 ---
 import type { Block, Props as $ } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 export type Props = $<Block>;
 

--- a/lab/src/components/ListItem.astro
+++ b/lab/src/components/ListItem.astro
@@ -1,6 +1,6 @@
 ---
 import type { Props as $, ListItem } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 type Props = $<ListItem>;
 

--- a/lab/src/components/ListWithRender.astro
+++ b/lab/src/components/ListWithRender.astro
@@ -1,6 +1,6 @@
 ---
 import type { List, Props as $ } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 export type Props = $<List>;
 

--- a/lab/src/components/Mark.astro
+++ b/lab/src/components/Mark.astro
@@ -1,6 +1,6 @@
 ---
 import type { Props as $, Mark } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 type Props = $<Mark>;
 

--- a/lab/src/components/MarkWithRender.astro
+++ b/lab/src/components/MarkWithRender.astro
@@ -1,6 +1,6 @@
 ---
 import type { Mark, Props as $ } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 export type Props = $<Mark>;
 

--- a/lab/src/components/MyBlock.astro
+++ b/lab/src/components/MyBlock.astro
@@ -1,6 +1,6 @@
 ---
 import type { Block, Props as $ } from "astro-portabletext/types";
-import { usePortableText } from "astro-portabletext/utils";
+import { usePortableText } from "astro-portabletext";
 
 export type Props = $<Block>;
 

--- a/lab/src/lib/utils.test.ts
+++ b/lab/src/lib/utils.test.ts
@@ -1,6 +1,14 @@
 import { suite } from "uvu";
 import * as assert from "uvu/assert";
-import { mergeComponents } from "astro-portabletext/utils";
+/**
+ * Importing `mergeComponents` from `astro-portabletext/utils` is deprecated and
+ * should be imported via `astro-portabletext` instead.
+ * However, due to the `PortableText` Astro component being part of `astro-portabletext`,
+ * it is not possible to import `mergeComponents` directly, as `tsm` throws an error.
+ * Therefore, importing `mergeComponents` using a relative path to `lib/utils` is necessary
+ * to mitigate the deprecation warning.
+ */
+import { mergeComponents } from "../../../astro-portabletext/lib/utils";
 
 // ----------------------------------------------------------------------------
 // Test `mergeComponents`


### PR DESCRIPTION
Consolidates exports in `index.ts` to simplify imports and improve the developer experience, including several refactorings to enhance code organisation and maintainability.

**Changes**

- The `usePortableText`, `toPlainText`, and `mergeComponents` utilities are now exported through `index.ts` to simplify imports. They have been marked as `deprecated` when imported via `astro-portabletext/utils`
- Consolidated types into `types.ts` for better organisation and updated related imports accordingly
- Adjusted test imports to reflect the new structure

**Benefits**

- Simplified imports: Users can now access utility functions through a single entry point (`astro-portabletext`), making the library easier to use
- Gradual deprecation: Deprecated exports from `astro-portabletext/utils` ensure users have time to migrate to the new import paths
- Centralised types and exports for improved code organisation and maintainability


**Testing**

All existing tests have been updated and are passing.