### PR TITLE
ci: add Node v22 to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds Node v22 to the test workflow to ensure compatibility with the latest Astro requirements