### PR TITLE
feat(api): simplify component prop imports with type aliases

### DIFF
--- a/astro-portabletext/docs/types/README.md
+++ b/astro-portabletext/docs/types/README.md
@@ -25,9 +25,14 @@
 | Type alias | Description |
 | ------ | ------ |
 | [SomePortableTextComponents](type-aliases/SomePortableTextComponents.md) | Object defining how some Portable Text types should be rendered |
+| [BlockProps](type-aliases/BlockProps.md) | Convenience type for [Block](interfaces/Block.md) component props |
 | [List](type-aliases/List.md) | Alias to [ToolkitPortableTextList](https://portabletext.github.io/toolkit/types/ToolkitPortableTextList.html) |
+| [ListProps](type-aliases/ListProps.md) | Convenience type for [List](type-aliases/List.md) component props |
 | [ListItem](type-aliases/ListItem.md) | Alias to [ToolkitPortableTextListItem](https://portabletext.github.io/toolkit/interfaces/ToolkitPortableTextListItem.html) |
+| [ListItemProps](type-aliases/ListItemProps.md) | Convenience type for [ListItem](type-aliases/ListItem.md) component props |
+| [MarkProps](type-aliases/MarkProps.md) | Convenience type for [Mark](interfaces/Mark.md) component props |
 | [TextNode](type-aliases/TextNode.md) | Alias to [ToolkitTextNode](https://portabletext.github.io/toolkit/interfaces/ToolkitTextNode.html) |
+| [TextNodeProps](type-aliases/TextNodeProps.md) | Convenience type for [TextNode](type-aliases/TextNode.md) component props |
 | [MissingComponentHandler](type-aliases/MissingComponentHandler.md) | The shape of the [onMissingComponent](interfaces/PortableTextProps.md#onMissingComponent) function |
 | [RenderHandlerProps](type-aliases/RenderHandlerProps.md) | Properties for the `RenderHandler` function |
 | [RenderHandler](type-aliases/RenderHandler.md) | The shape of the render component function |

--- a/astro-portabletext/docs/types/type-aliases/BlockProps.md
+++ b/astro-portabletext/docs/types/type-aliases/BlockProps.md
@@ -1,0 +1,11 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / BlockProps
+
+# Type Alias: BlockProps
+
+> **BlockProps**: [`Props`](../interfaces/Props.md)\<[`Block`](../interfaces/Block.md)\>
+
+Convenience type for [Block](../interfaces/Block.md) component props

--- a/astro-portabletext/docs/types/type-aliases/ListItemProps.md
+++ b/astro-portabletext/docs/types/type-aliases/ListItemProps.md
@@ -1,0 +1,11 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / ListItemProps
+
+# Type Alias: ListItemProps
+
+> **ListItemProps**: [`Props`](../interfaces/Props.md)\<[`ListItem`](ListItem.md)\>
+
+Convenience type for [ListItem](ListItem.md) component props

--- a/astro-portabletext/docs/types/type-aliases/ListProps.md
+++ b/astro-portabletext/docs/types/type-aliases/ListProps.md
@@ -1,0 +1,11 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / ListProps
+
+# Type Alias: ListProps
+
+> **ListProps**: [`Props`](../interfaces/Props.md)\<[`List`](List.md)\>
+
+Convenience type for [List](List.md) component props

--- a/astro-portabletext/docs/types/type-aliases/MarkProps.md
+++ b/astro-portabletext/docs/types/type-aliases/MarkProps.md
@@ -1,0 +1,15 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / MarkProps
+
+# Type Alias: MarkProps\<MarkDef\>
+
+> **MarkProps**\<`MarkDef`\>: [`Props`](../interfaces/Props.md)\<[`Mark`](../interfaces/Mark.md)\<`MarkDef`\>\>
+
+Convenience type for [Mark](../interfaces/Mark.md) component props
+
+## Type Parameters
+
+• **MarkDef** *extends* `Record`\<`string`, `unknown`\> \| `undefined` = `undefined`

--- a/astro-portabletext/docs/types/type-aliases/TextNodeProps.md
+++ b/astro-portabletext/docs/types/type-aliases/TextNodeProps.md
@@ -1,0 +1,11 @@
+[**astro-portabletext**](../../README.md)
+
+***
+
+[astro-portabletext](../../README.md) / [types](../README.md) / TextNodeProps
+
+# Type Alias: TextNodeProps
+
+> **TextNodeProps**: [`Props`](../interfaces/Props.md)\<[`TextNode`](TextNode.md)\>
+
+Convenience type for [TextNode](TextNode.md) component props

--- a/astro-portabletext/lib/types.ts
+++ b/astro-portabletext/lib/types.ts
@@ -147,6 +147,11 @@ export interface Block extends PortableTextBlock {
 }
 
 /**
+ * Convenience type for {@link Block} component props
+ */
+export type BlockProps = Props<Block>;
+
+/**
  * Alias to {@link https://portabletext.github.io/toolkit/types/ToolkitPortableTextList.html ToolkitPortableTextList}
  *
  * @example
@@ -161,6 +166,11 @@ export interface Block extends PortableTextBlock {
 export type List = ToolkitPortableTextList;
 
 /**
+ * Convenience type for {@link List} component props
+ */
+export type ListProps = Props<List>;
+
+/**
  * Alias to {@link https://portabletext.github.io/toolkit/interfaces/ToolkitPortableTextListItem.html ToolkitPortableTextListItem}
  *
  * @example
@@ -173,6 +183,11 @@ export type List = ToolkitPortableTextList;
  * ```
  */
 export type ListItem = ToolkitPortableTextListItem;
+
+/**
+ * Convenience type for {@link ListItem} component props
+ */
+export type ListItemProps = Props<ListItem>;
 
 /**
  * Extends {@link https://portabletext.github.io/toolkit/interfaces/ToolkitNestedPortableTextSpan.html ToolkitNestedPortableTextSpan}
@@ -205,6 +220,13 @@ export interface Mark<
 }
 
 /**
+ * Convenience type for {@link Mark} component props
+ */
+export type MarkProps<
+  MarkDef extends Record<string, unknown> | undefined = undefined,
+> = Props<Mark<MarkDef>>;
+
+/**
  * Alias to {@link https://portabletext.github.io/toolkit/interfaces/ToolkitTextNode.html ToolkitTextNode}
  *
  * @example
@@ -217,6 +239,11 @@ export interface Mark<
  * ```
  */
 export type TextNode = ToolkitTextNode;
+
+/**
+ * Convenience type for {@link TextNode} component props
+ */
+export type TextNodeProps = Props<TextNode>;
 
 /**
  * The shape of the {@link PortableTextProps.onMissingComponent onMissingComponent} function


### PR DESCRIPTION
Added type aliases for component props to simplify user imports and improve type readability. The type aliases include: `BlockProps`, `ListProps`, `ListItemProps`, `MarkProps<MarkDef>`, and `TextNodeProps`.


```diff
- import type { Props as $, Block } from "astro-portabletext/types";
+ import type { BlockProps } from "astro-portabletext/types";

- type Props = $<Block>;
+ type Props = BlockProps;
```