### PR TITLE
Fix typo that breaks custom components

### DIFF
--- a/astro-portabletext/components/PortableText.astro
+++ b/astro-portabletext/components/PortableText.astro
@@ -117,7 +117,7 @@ const provideComponent = (
   fallbackComponent: Component
 ): Component => {
   const component: Component | undefined = ((component) => {
-    return component[type as keyof typeof component] || component;
+    return components[type as keyof typeof component] || component;
   })(components[nodeType]);
 
   if (isComponent(component)) {


### PR DESCRIPTION
Could this be a typo?

Without this change, if I create a custom component `CaptionedImage.astro`, and use it like this, according to [the docs][docs]:

```
{<PortableText value={article.content} components={{captionedImage: CaptionedImage}} />}
```

I get this error:

```
PortableText [components.type] is missing "captionedImage"
```

But on fixing what looks like a typo to me, everything works fine.

[docs]: https://github.com/theisel/astro-portabletext/blob/main/astro-portabletext/README.md#custom-components---full-control