### PR TITLE
docs(root): update documentation links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ $ npm install astro-portabletext
 
 ## Documentation
 
-`How to` and `examples` can be found [here](astro-portabletext/README.md "astro-portabletext documentation").
+`How to` and `examples` can be found here:
+* [Documentation for latest stable version (0.10.1)](https://github.com/theisel/astro-portabletext/tree/astro-portabletext%400.10.1/astro-portabletext "astro-portabletext 0.10.1 documentation")
+* [Documentation for in-development version (`main` branch)](astro-portabletext/README.md "astro-portabletext main branch documentation")
 
 &nbsp;
 


### PR DESCRIPTION
Hey,

This addresses my confusion in #173.

I'm sure there's a better way to do this that won't require editing the README on release. Maybe using a git tag or something?

But anyway, I think this is an improvement that would already help for now, so users don't end up on the wrong docs.