### PR TITLE
feat(api): add `spanToPlainText` function (docs updated)

### DIFF
--- a/astro-portabletext/lib/utils.d.ts
+++ b/astro-portabletext/lib/utils.d.ts
@@ -6,6 +6,12 @@ declare module "astro-portabletext/utils" {
     ...args: Parameters<typeof import("@portabletext/toolkit").toPlainText>
   ): ReturnType<typeof import("@portabletext/toolkit").toPlainText>;
   /**
+   * @deprecated Use `spanToPlainText` from `astro-portabletext` instead
+   */
+  export function spanToPlainText(
+    ...args: Parameters<typeof import("@portabletext/toolkit").spanToPlainText>
+  ): ReturnType<typeof import("@portabletext/toolkit").spanToPlainText>;
+  /**
    * @deprecated Use `mergeComponents` from `astro-portabletext` instead
    */
   export function mergeComponents(

--- a/astro-portabletext/lib/utils.ts
+++ b/astro-portabletext/lib/utils.ts
@@ -1,3 +1,3 @@
-export { toPlainText } from "@portabletext/toolkit";
+export { toPlainText, spanToPlainText } from "@portabletext/toolkit";
 export { mergeComponents } from "./internal";
 export { usePortableText } from "./context";

--- a/docs/utility-functions.md
+++ b/docs/utility-functions.md
@@ -43,3 +43,11 @@ Combines two sets of `components` options, where `overrideComponents` takes prec
 Extracts the text content from Portable Text blocks, preserving spacing.
 
 💡 Refer to `@portabletext/toolkit` [toPlainText](https://portabletext.github.io/toolkit/functions/toPlainText.html) documentation for more details.
+
+## `spanToPlainText`
+
+> **spanToPlainText**(`span`): `string`
+
+Returns plain text from a Portable Text span, useful for extracting text from nested nodes.
+
+💡 Refer to `@portabletext/toolkit` [spanToPlainText](https://portabletext.github.io/toolkit/functions/spanToPlainText.html) documentation for more details.


### PR DESCRIPTION
Adds the `spanToPlainText` function to the library's API for extracting text from Portable Text spans (see [https://portabletext.github.io/toolkit/functions/spanToPlainText.html](https://portabletext.github.io/toolkit/functions/spanToPlainText.html)).

```js
import { spanToPlainText } from "astro-portabletext";
```

**Deprecation:** The import path `astro-portabletext/utils` for `spanToPlainText` is deprecated. This utility path will be removed in a future release.

Documentation updated.

Closes #178