### PR TITLE
chore: remove `group-pull-request-title-pattern` from release config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "include-v-in-tag": false,
   "tag-separator": "@",
   "pull-request-header": ":robot: release created",
-  "group-pull-request-title-pattern": "chore: batch release ${branch}",
   "plugins": ["node-workspace"],
   "release-type": "node",
   "changelog-sections": [


### PR DESCRIPTION
Removes the `group-pull-request-title-pattern` from the release configuration in an attempt to resolve issues with the `release-please` action not releasing as expected. Further investigation is needed if the release still fails.