### PR TITLE
chore(release): update last release SHA in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "cffbdf8deff5522516124615e694ee9754c23e07",
+  "last-release-sha": "b59dd9a384340451a332a7fbd1e807f95e5ed8e3",
   "bump-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": false,


### PR DESCRIPTION
## Problem

Release-please is generating unnecessary release notes, possibly due to an incorrect last release SHA.

## Solution

Updates the last release SHA in the release-please config to the correct value: b59dd9a384340451a332a7fbd1e807f95e5ed8e3.

## Expected Behavior

Release-please should now only generate release notes for actual new releases.