### PR TITLE
chore(release): update astro-portabletext version to 0.11.0 in release manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"astro-portabletext":"0.10.1"}
+{"astro-portabletext":"0.11.0"}


### PR DESCRIPTION
## Problem

`release-please` failed to update `astro-portabletext` to `0.11.0` in the release manifest.

## Solution

Manually update `astro-portabletext` to `0.11.0` in `.release-please-manifest.json`.
