### PR TITLE
chore(release): manually update `version` and `last-release-sha` in release-please manifest and config files

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"astro-portabletext":"0.11.0"}
+{"astro-portabletext":"0.11.1"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "b59dd9a384340451a332a7fbd1e807f95e5ed8e3",
+  "last-release-sha": "f3f2ce5146d3ee5bdf93955a229125b7b783645d",
   "bump-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": false,


### PR DESCRIPTION
Manually updates the `release-please-manifest.json` file to v0.11.1. There is an issue with the `release-please` action not updating this file automatically and produces a fresh release PR upon release.

Updates the `last-release-sha` in `release-please-config.json` to reflect the latest release.