### PR TITLE
chore(release): fix release-please manifest update

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "last-release-sha": "f3f2ce5146d3ee5bdf93955a229125b7b783645d",
   "bump-minor-pre-major": true,
+  "separate-pull-requests": false,
   "include-component-in-tag": true,
   "include-v-in-tag": false,
   "tag-separator": "@",


### PR DESCRIPTION
Sets `separate-pull-requests` explicitly to false. See [googleapis/release-please#2172](https://github.com/googleapis/release-please/issues/2172).

Hopefully this issue is now resolved.