### PR TITLE
docs(user-guide): add `spanToPlainText` import and v0.11.0 note

### DIFF
--- a/docs/utility-functions.md
+++ b/docs/utility-functions.md
@@ -12,6 +12,7 @@ import {
   usePortableText,
   mergeComponents,
   toPlainText,
+  spanToPlainText,
 } from "astro-portabletext";
 
 // Deprecated
@@ -47,6 +48,10 @@ Extracts the text content from Portable Text blocks, preserving spacing.
 ## `spanToPlainText`
 
 > **spanToPlainText**(`span`): `string`
+
+
+> Added in v0.11.0
+
 
 Returns plain text from a Portable Text span, useful for extracting text from nested nodes.
 


### PR DESCRIPTION
Added the missing `spanToPlainText` import to the code example and noted its introduction in v0.11.0 within the relevant section.