### PR TITLE
fix(astro-portabletext): update dependencies to latest versions

### DIFF
--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -48,8 +48,8 @@
     "check": "astro check --root components"
   },
   "dependencies": {
-    "@portabletext/toolkit": "^2.0.17",
-    "@portabletext/types": "^2.0.13"
+    "@portabletext/toolkit": "^3.0.0",
+    "@portabletext/types": "^2.0.15"
   },
   "peerDependencies": {
     "astro": ">=4.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,11 +75,11 @@ importers:
   astro-portabletext:
     dependencies:
       '@portabletext/toolkit':
-        specifier: ^2.0.17
-        version: 2.0.17
+        specifier: ^3.0.0
+        version: 3.0.0
       '@portabletext/types':
-        specifier: ^2.0.13
-        version: 2.0.13
+        specifier: ^2.0.15
+        version: 2.0.15
       astro:
         specifier: '>=4.6.0'
         version: 5.2.5(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.34.7)(typescript@5.9.2)(yaml@2.8.1)
@@ -809,12 +809,16 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@portabletext/toolkit@2.0.17':
-    resolution: {integrity: sha512-5wj+oUaCmHm9Ay1cytPmT1Yc0SrR1twwUIc0qNQ3MtaXaNMPw99Gjt1NcA34yfyKmEf/TAB2NiiT72jFxdddIQ==}
+  '@portabletext/toolkit@2.0.18':
+    resolution: {integrity: sha512-m3v2WwKQTNNk5BFZlUuPuCW0Zi6iDSpwrium4Ej5L2FHDXhFuwAyEMPXDrvwPvqjES/oJzcwmdKLMhYa44T9BQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
-  '@portabletext/types@2.0.13':
-    resolution: {integrity: sha512-5xk5MSyQU9CrDho3Rsguj38jhijhD36Mk8S6mZo3huv6PM+t4M/5kJN2KFIxgvt4ONpvOEs1pVIZAV0cL0Vi+Q==}
+  '@portabletext/toolkit@3.0.0':
+    resolution: {integrity: sha512-50otiRkac8unAAU+U9VdhpkZ4FqTG64kzz/6ckeBigKG/cGSU8YZLfmvDhdMH8tw+/uTI7d9Skwqm8RnTHZwDw==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
+  '@portabletext/types@2.0.15':
+    resolution: {integrity: sha512-2e6i2gSQsrA/5OL5Gm4/9bxB9MNO73Fa47zj+0mT93xkoQUCGCWX5fZh1YBJ86hszaRYlqvqG08oULxvvPPp/Q==}
     engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
 
   '@rollup/pluginutils@5.1.4':
@@ -4255,11 +4259,15 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@portabletext/toolkit@2.0.17':
+  '@portabletext/toolkit@2.0.18':
     dependencies:
-      '@portabletext/types': 2.0.13
+      '@portabletext/types': 2.0.15
 
-  '@portabletext/types@2.0.13': {}
+  '@portabletext/toolkit@3.0.0':
+    dependencies:
+      '@portabletext/types': 2.0.15
+
+  '@portabletext/types@2.0.15': {}
 
   '@rollup/pluginutils@5.1.4(rollup@4.34.7)':
     dependencies:
@@ -4677,8 +4685,8 @@ snapshots:
 
   astro-portabletext@0.11.1(astro@5.3.0(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.34.7)(typescript@5.9.2)(yaml@2.8.1)):
     dependencies:
-      '@portabletext/toolkit': 2.0.17
-      '@portabletext/types': 2.0.13
+      '@portabletext/toolkit': 2.0.18
+      '@portabletext/types': 2.0.15
       astro: 5.3.0(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.34.7)(typescript@5.9.2)(yaml@2.8.1)
 
   astro@5.2.5(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.34.7)(typescript@5.9.2)(yaml@2.8.1):


### PR DESCRIPTION
This PR updates all dependencies to their latest versions, most notably `@portabletext/toolkit` to v3.

This is a non-breaking change for this library. The major bump in the toolkit was the removal of Node 14 support, which does not affect this library's minimum requirement of Node 18+.