### PR TITLE
feat(deps)!: bump dependencies requiring Node >=20.19

### DIFF
--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -48,10 +48,13 @@
     "check": "astro check --root components"
   },
   "dependencies": {
-    "@portabletext/toolkit": "^3.0.1",
-    "@portabletext/types": "^2.0.15"
+    "@portabletext/toolkit": "^4.0.0",
+    "@portabletext/types": "^3.0.0"
   },
   "peerDependencies": {
     "astro": ">=4.6.0"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,11 +75,11 @@ importers:
   astro-portabletext:
     dependencies:
       '@portabletext/toolkit':
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^4.0.0
+        version: 4.0.0
       '@portabletext/types':
-        specifier: ^2.0.15
-        version: 2.0.15
+        specifier: ^3.0.0
+        version: 3.0.0
       astro:
         specifier: '>=4.6.0'
         version: 5.2.5(@types/node@24.10.0)(jiti@2.6.1)(rollup@4.34.7)(typescript@5.9.3)(yaml@2.8.1)
@@ -810,13 +810,17 @@ packages:
     resolution: {integrity: sha512-m3v2WwKQTNNk5BFZlUuPuCW0Zi6iDSpwrium4Ej5L2FHDXhFuwAyEMPXDrvwPvqjES/oJzcwmdKLMhYa44T9BQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
-  '@portabletext/toolkit@3.0.1':
-    resolution: {integrity: sha512-z8NGqxKxfP0zuC58hPe8+xFC17qSbQ3nC9DgZmhrr7NUFaENJ6vAHJBsH5QzT7nKUjj++dTn+i4O2Uz9cqiGjA==}
-    engines: {node: ^14.13.1 || >=16.0.0}
+  '@portabletext/toolkit@4.0.0':
+    resolution: {integrity: sha512-Jj/QIy3vzZCNcxiUGM7KjGhUhyVjch+9pOzotWRARPNe07R6nbF/cRsKL70q5Xizf+6PVtFYwks4CSXKInC+wg==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@portabletext/types@2.0.15':
     resolution: {integrity: sha512-2e6i2gSQsrA/5OL5Gm4/9bxB9MNO73Fa47zj+0mT93xkoQUCGCWX5fZh1YBJ86hszaRYlqvqG08oULxvvPPp/Q==}
     engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
+
+  '@portabletext/types@3.0.0':
+    resolution: {integrity: sha512-7U8+bFcnguNtXr4rwMDj0EvJJDRzLaaof2mQqCjUcqxuuJpAppFaATZgrKmPI1uBgtFMi4unk1nIaOOmLHrX8Q==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
@@ -4270,11 +4274,13 @@ snapshots:
     dependencies:
       '@portabletext/types': 2.0.15
 
-  '@portabletext/toolkit@3.0.1':
+  '@portabletext/toolkit@4.0.0':
     dependencies:
-      '@portabletext/types': 2.0.15
+      '@portabletext/types': 3.0.0
 
   '@portabletext/types@2.0.15': {}
+
+  '@portabletext/types@3.0.0': {}
 
   '@rollup/pluginutils@5.1.4(rollup@4.34.7)':
     dependencies:


### PR DESCRIPTION
This PR updates `@portabletext/toolkit` and `@portabletext/types` to their latest major versions.

### Breaking Change

These upstream dependencies introduce a new, specific Node engine requirement. The library's `package.json` has been updated to reflect this:

```json
"engines": {
  "node": ">=20.19 <22 || >=22.12"
}
```

### References

- [`@portabletext/toolkit` v4.0.0](https://github.com/portabletext/toolkit/blob/v4.0.0/package.json#L75)
- [`@portabletext/types` v3.0.0](https://github.com/portabletext/types/blob/v3.0.0/package.json#L62)