### PR TITLE
Fix published utils export

### DIFF
--- a/astro-portabletext/lib/context.ts
+++ b/astro-portabletext/lib/context.ts
@@ -1,5 +1,5 @@
 import type { TypedObject } from "@portabletext/types";
-import type { Context } from "./types";
+import type { Context } from "./types.js";
 
 export const key = Symbol("astro-portabletext");
 

--- a/astro-portabletext/lib/internal.ts
+++ b/astro-portabletext/lib/internal.ts
@@ -3,7 +3,7 @@ import type {
   ComponentOrRecord,
   SomePortableTextComponents,
   TypedObject,
-} from "./types";
+} from "./types.js";
 
 /**
  * Helper for component to throw an error
@@ -62,8 +62,8 @@ export function mergeComponents<
       !current || isComponent(override) || isComponent(current)
         ? override
         : {
-            ...current,
-            ...override,
+            ...(current as Record<string, Component>),
+            ...(override as Record<string, Component>),
           };
 
     cmps[key] = value;

--- a/astro-portabletext/lib/utils.ts
+++ b/astro-portabletext/lib/utils.ts
@@ -1,3 +1,3 @@
 export { toPlainText, spanToPlainText } from "@portabletext/toolkit";
-export { mergeComponents } from "./internal";
-export { usePortableText } from "./context";
+export { mergeComponents } from "./internal.js";
+export { usePortableText } from "./context.js";

--- a/astro-portabletext/package.json
+++ b/astro-portabletext/package.json
@@ -19,8 +19,8 @@
     "./types": "./lib/types.ts",
     "./utils": {
       "types": "./lib/utils.d.ts",
-      "import": "./lib/utils.ts",
-      "default": "./lib/utils.ts"
+      "import": "./lib/utils.js",
+      "default": "./lib/utils.js"
     }
   },
   "typesVersions": {
@@ -45,6 +45,8 @@
   },
   "homepage": "https://github.com/theisel/astro-portabletext#readme",
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "check": "astro check --root components"
   },
   "dependencies": {

--- a/astro-portabletext/tsconfig.build.json
+++ b/astro-portabletext/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "lib",
+    "removeComments": true,
+    "rootDir": "lib",
+    "target": "ES2022"
+  },
+  "include": ["lib/context.ts", "lib/internal.ts", "lib/types.ts", "lib/utils.ts"]
+}


### PR DESCRIPTION
## Summary

- point the published `astro-portabletext/utils` export at generated JavaScript instead of the TypeScript source file
- add a package `prepack` build that emits the JS used by that subpath
- update internal relative imports so the emitted ESM resolves in Node

## Reproduction

With the published `astro-portabletext@0.13.0` package:

```sh
mkdir repro && cd repro
npm init -y
npm install astro-portabletext@0.13.0
node --input-type=module -e "await import('astro-portabletext/utils')"
```

Node fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` because the subpath resolves to `lib/utils.ts` under `node_modules`.

After this change, `npm pack` runs the package build and the packed tarball contains `lib/utils.js`, `lib/context.js`, and `lib/internal.js`; installing that tarball in a clean project allows `import('astro-portabletext/utils')` to succeed.

## Validation

- `corepack pnpm --dir astro-portabletext build`
- `corepack pnpm --dir astro-portabletext check`
- `corepack pnpm --dir lab check`
- `corepack pnpm --dir lab exec uvu -r tsm src/lib`
- `corepack pnpm --dir lab build:fixture`
- `corepack pnpm --dir lab exec uvu src/test .test.js`
- `corepack pnpm lint`
- `npm pack --json --pack-destination <temp>` from `astro-portabletext/`, then clean install of the tarball and `import('astro-portabletext/utils')`

Note: `pnpm test:ci` is a shell wrapper (`./scripts/ci.sh`) and does not run directly in this Windows environment, so I ran the same underlying commands individually.
