### PR TITLE
ci(release): upgrade release-please action and authorize downstream workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release / Pull Request
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
 
       - name: Publish to NPM?

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Release / Pull Request
         uses: googleapis/release-please-action@v5
         id: release
+        with:
+          token: ${{ secrets.CI_TOKEN }}
 
       - name: Publish to NPM?
         id: npm


### PR DESCRIPTION
Upgrade `googleapis/release-please-action` to v5 and pass a Personal Access Token to ensure downstream workflows get triggered.

### Key Changes
- **Upgrade to v5:** Migrate `release-please` action to v5, running on `node24`, to resolve the GitHub Actions `node20` deprecation warning.
- **Authorize Lockfile Sync:** Pass a Personal Access Token (PAT) to the action. This ensures the PR created by the bot triggers the `Release Please PR` downstream workflow to sync the `pnpm-lock.yaml` file.