### PR TITLE
chore: post-v1.0.0 release cleanup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           token: ${{ secrets.CI_TOKEN }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v6

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           token: ${{ secrets.CI_TOKEN }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           token: ${{ secrets.CI_TOKEN }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v6

--- a/demo/package.json
+++ b/demo/package.json
@@ -18,7 +18,7 @@
     "@astrojs/solid-js": "^7.0.2",
     "@astrojs/svelte": "^9.0.1",
     "astro": "^7.2.2",
-    "astro-portabletext": "^0.13.0",
+    "astro-portabletext": "^1.0.0",
     "solid-js": "^1.9.14",
     "svelte": "^5.56.9"
   },

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -1,4 +1,4 @@
-**`astro-portabletext` v0.13.0 • Type Definitions**
+**`astro-portabletext` v1.0.0 • Type Definitions**
 
 ---
 

--- a/docs/types/interfaces/Block.md
+++ b/docs/types/interfaces/Block.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/interfaces/Context.md
+++ b/docs/types/interfaces/Context.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/interfaces/Mark.md
+++ b/docs/types/interfaces/Mark.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/interfaces/PortableTextComponents.md
+++ b/docs/types/interfaces/PortableTextComponents.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/interfaces/PortableTextProps.md
+++ b/docs/types/interfaces/PortableTextProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/interfaces/Props.md
+++ b/docs/types/interfaces/Props.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/interfaces/TypedObject.md
+++ b/docs/types/interfaces/TypedObject.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/BlockProps.md
+++ b/docs/types/type-aliases/BlockProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/Component.md
+++ b/docs/types/type-aliases/Component.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/ComponentOrRecord.md
+++ b/docs/types/type-aliases/ComponentOrRecord.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/List.md
+++ b/docs/types/type-aliases/List.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/ListItem.md
+++ b/docs/types/type-aliases/ListItem.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/ListItemProps.md
+++ b/docs/types/type-aliases/ListItemProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/ListProps.md
+++ b/docs/types/type-aliases/ListProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/MarkProps.md
+++ b/docs/types/type-aliases/MarkProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/MissingComponentHandler.md
+++ b/docs/types/type-aliases/MissingComponentHandler.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/NodeType.md
+++ b/docs/types/type-aliases/NodeType.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/RenderHandler.md
+++ b/docs/types/type-aliases/RenderHandler.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/RenderHandlerProps.md
+++ b/docs/types/type-aliases/RenderHandlerProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/RenderOptions.md
+++ b/docs/types/type-aliases/RenderOptions.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/SomePortableTextComponents.md
+++ b/docs/types/type-aliases/SomePortableTextComponents.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/TextNode.md
+++ b/docs/types/type-aliases/TextNode.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/TextNodeProps.md
+++ b/docs/types/type-aliases/TextNodeProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/docs/types/type-aliases/TypedObjectProps.md
+++ b/docs/types/type-aliases/TypedObjectProps.md
@@ -1,4 +1,4 @@
-[**`astro-portabletext` v0.13.0 • Type Definitions**](../README.md)
+[**`astro-portabletext` v1.0.0 • Type Definitions**](../README.md)
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^7.2.2
         version: 7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)
       astro-portabletext:
-        specifier: ^0.13.0
-        version: 0.13.0(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0))
+        specifier: ^1.0.0
+        version: 1.0.0(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0))
       solid-js:
         specifier: ^1.9.14
         version: 1.9.15
@@ -970,10 +970,6 @@ packages:
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
-  '@portabletext/toolkit@5.0.2':
-    resolution: {integrity: sha512-Njc1LE1PMJkTx/wEPqZ6sOWGgFgX2B47fxpOQ/Ia4ByhsZoA5Sq8dNvvV5F052j/xE8TbOLiBEjS848FkKADDQ==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-
   '@portabletext/toolkit@6.0.0':
     resolution: {integrity: sha512-+qSqe0KnefuZfNLUhzQRTpbSKxslZof+3pNwxg0DC8dfZ1yLKyyBUw6iR7EpDL+SJlrnpiBfEcfmEuFitK1NSQ==}
     engines: {node: '>=22.12'}
@@ -1383,9 +1379,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  astro-portabletext@0.13.0:
-    resolution: {integrity: sha512-Z9N32H7eRP8tuSavnJqUm4vKqHj59oYEyhqq4YiwsAcFnwDbepbb6cmIRGG5S+eejvHibrjyAKdQxhVINYXCbA==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
+  astro-portabletext@1.0.0:
+    resolution: {integrity: sha512-7oj+cvbfq++WfD9lw4NGu6rZnbchDGfRsgCgzys/20QhinCjjwL4XO+iKse0dNofXI/cVyiHXdTg/K6InScryg==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
       astro: '>=4.6.0'
 
@@ -3874,10 +3870,6 @@ snapshots:
 
   '@oxc-project/types@0.146.0': {}
 
-  '@portabletext/toolkit@5.0.2':
-    dependencies:
-      '@portabletext/types': 4.0.2
-
   '@portabletext/toolkit@6.0.0':
     dependencies:
       '@portabletext/types': 4.0.2
@@ -4312,9 +4304,9 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astro-portabletext@0.13.0(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)):
+  astro-portabletext@1.0.0(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
-      '@portabletext/toolkit': 5.0.2
+      '@portabletext/toolkit': 6.0.0
       '@portabletext/types': 4.0.2
       astro: 7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)
 


### PR DESCRIPTION
- Update the `demo` workspace to consume `astro-portabletext@1.0.0`.
- Fix the `actions/checkout` detached HEAD bug in CI workflows.
- Sync the generated documentation missed during the release.